### PR TITLE
Refractor/error logging

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SOURCES
     src/ast.c
     src/parser.c
     src/util.c
+    src/error.c
     src/sema.c
     src/codegen.c
 )

--- a/compiler/include/ast.h
+++ b/compiler/include/ast.h
@@ -108,7 +108,7 @@ typedef struct {
 // ---- AST Node ----
 struct AstNode {
     NodeKind kind;
-    int line;
+    Token tok;
 
     union {
         // NODE_PROGRAM
@@ -258,7 +258,7 @@ struct AstNode {
 };
 
 // Constructors
-AstNode *ast_new(NodeKind kind, int line);
+AstNode *ast_new(NodeKind kind, Token tok);
 AstType *ast_type_simple(TypeKind kind);
 AstType *ast_type_array(AstType *element);
 AstType *ast_type_named(const char *name);

--- a/compiler/include/error.h
+++ b/compiler/include/error.h
@@ -1,0 +1,8 @@
+#ifndef SEMA_ERROR_H
+#define SEMA_ERROR_H
+
+#include "token.h"
+
+void report_error(const char *filename, Token *t, const char *msg);
+
+#endif

--- a/compiler/include/lexer.h
+++ b/compiler/include/lexer.h
@@ -8,6 +8,7 @@ typedef struct {
     size_t length;
     size_t pos;
     int line;
+    int line_start;
 } Lexer;
 
 void lexer_init(Lexer *l, const char *source, size_t length);

--- a/compiler/include/parser.h
+++ b/compiler/include/parser.h
@@ -7,6 +7,7 @@
 
 typedef struct {
     Token *tokens;
+    const char *filename;
     int count;
     int pos;
     bool had_error;

--- a/compiler/include/sema.h
+++ b/compiler/include/sema.h
@@ -5,6 +5,6 @@
 #include <stdbool.h>
 
 // Returns true if analysis succeeded (no errors)
-bool sema_analyze(AstNode *program);
+bool sema_analyze(AstNode *program, const char *filename);
 
 #endif

--- a/compiler/include/token.h
+++ b/compiler/include/token.h
@@ -87,6 +87,7 @@ typedef struct {
     const char *start;
     size_t length;
     int line;
+    int col;
 } Token;
 
 const char *token_type_name(TokenType type);

--- a/compiler/src/ast.c
+++ b/compiler/src/ast.c
@@ -7,10 +7,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-AstNode *ast_new(NodeKind kind, int line) {
+AstNode *ast_new(NodeKind kind, Token tok) {
     AstNode *n = calloc(1, sizeof(AstNode));
     n->kind = kind;
-    n->line = line;
+    n->tok = tok;
     return n;
 }
 

--- a/compiler/src/error.c
+++ b/compiler/src/error.c
@@ -1,0 +1,28 @@
+#include "token.h"
+#include "error.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+void report_error(const char *filename, Token *t, const char *msg) {
+    fprintf(stderr, "\x1b[1m%s:%d: \x1b[31mError\x1b[0m: %s\n", filename, t->line, msg);
+
+    FILE *f = fopen(filename, "r");
+    if (f) {
+        char *buffer = NULL;
+        size_t n = 0;
+        for (int i = 1; i <= t->line; i++) {
+            if (getline(&buffer, &n, f) != -1 && i == t->line) {
+                fprintf(stderr, "  %-5d | %s", t->line, buffer);
+                fprintf(stderr, "        | ");
+                for (int j = 1; j < t->col; j++) fprintf(stderr, " ");
+                fprintf(stderr, "\033[1;32m");
+
+                for (size_t k = 0; k < t->length; k++) fprintf(stderr, "^");
+                fprintf(stderr, "\033[0m\n");
+
+                free(buffer);
+            }
+        }
+        fclose(f);
+    }
+}

--- a/compiler/src/lexer.c
+++ b/compiler/src/lexer.c
@@ -23,7 +23,10 @@ static char peek_next(Lexer *l) {
 
 static char advance(Lexer *l) {
     char c = l->source[l->pos++];
-    if (c == '\n') l->line++;
+    if (c == '\n') {
+        l->line++;
+        l->line_start = l->pos;
+    }
     return c;
 }
 
@@ -50,7 +53,7 @@ static void skip_whitespace(Lexer *l) {
 }
 
 static Token make_token(Lexer *l, TokenType type, const char *start, size_t len) {
-    return (Token){ .type = type, .start = start, .length = len, .line = l->line };
+    return (Token){ .type = type, .start = start, .length = len, .line = l->line, .col = (int)(start - (l->source + l->line_start)) + 1 };
 }
 
 static Token error_token(Lexer *l, const char *msg) {

--- a/compiler/src/main.c
+++ b/compiler/src/main.c
@@ -299,7 +299,7 @@ int main(int argc, char **argv) {
     }
 
     // Semantic analysis
-    if (!sema_analyze(program)) {
+    if (!sema_analyze(program, path)) {
         fprintf(stderr, "Semantic analysis failed.\n");
         ast_free(program);
         free(tokens);

--- a/compiler/src/main.c
+++ b/compiler/src/main.c
@@ -143,6 +143,7 @@ static bool process_imports(AstNode *program, const char *base_file) {
         }
 
         Parser parser;
+        parser.filename = path;
         parser_init(&parser, tokens, token_count);
         AstNode *imported = parser_parse(&parser);
 
@@ -271,6 +272,7 @@ int main(int argc, char **argv) {
 
     // Parsing
     Parser parser;
+    parser.filename = path;
     parser_init(&parser, tokens, token_count);
     AstNode *program = parser_parse(&parser);
 

--- a/compiler/src/parser.c
+++ b/compiler/src/parser.c
@@ -3,6 +3,7 @@
 #endif
 
 #include "parser.h"
+#include "error.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -41,8 +42,7 @@ static Token advance_tok(Parser *p) {
 static void error_at(Parser *p, Token t, const char *msg) {
     if (p->had_error) return;
     p->had_error = true;
-    fprintf(stderr, "[line %d] Error at '%.*s': %s\n",
-            t.line, (int)t.length, t.start, msg);
+    report_error(p->filename, &t, msg);
 }
 
 static Token expect(Parser *p, TokenType type, const char *msg) {

--- a/compiler/src/parser.c
+++ b/compiler/src/parser.c
@@ -140,9 +140,9 @@ static AstNode *parse_fstring(Parser *p, Token t) {
                 AstNode *expr = parse_expr(&sub_parser);
 
                 // Wrap in to_str() call
-                AstNode *to_str_ident = ast_new(NODE_IDENT, t.line);
+                AstNode *to_str_ident = ast_new(NODE_IDENT, t);
                 to_str_ident->as.ident.name = strdup("to_str");
-                AstNode *call = ast_new(NODE_CALL, t.line);
+                AstNode *call = ast_new(NODE_CALL, t);
                 call->as.call.callee = to_str_ident;
                 call->as.call.args = malloc(sizeof(AstNode *));
                 call->as.call.args[0] = expr;
@@ -151,7 +151,7 @@ static AstNode *parse_fstring(Parser *p, Token t) {
                 if (!result) {
                     result = call;
                 } else {
-                    AstNode *bin = ast_new(NODE_BINARY, t.line);
+                    AstNode *bin = ast_new(NODE_BINARY, t);
                     bin->as.binary.left = result;
                     bin->as.binary.op = TOK_PLUS;
                     bin->as.binary.right = call;
@@ -167,13 +167,13 @@ static AstNode *parse_fstring(Parser *p, Token t) {
                 i++;
             }
             if (i > start) {
-                AstNode *lit = ast_new(NODE_STR_LIT, t.line);
+                AstNode *lit = ast_new(NODE_STR_LIT, t);
                 lit->as.str_lit.value = ast_strdup(raw + start, i - start);
 
                 if (!result) {
                     result = lit;
                 } else {
-                    AstNode *bin = ast_new(NODE_BINARY, t.line);
+                    AstNode *bin = ast_new(NODE_BINARY, t);
                     bin->as.binary.left = result;
                     bin->as.binary.op = TOK_PLUS;
                     bin->as.binary.right = lit;
@@ -184,7 +184,7 @@ static AstNode *parse_fstring(Parser *p, Token t) {
     }
 
     if (!result) {
-        result = ast_new(NODE_STR_LIT, t.line);
+        result = ast_new(NODE_STR_LIT, t);
         result->as.str_lit.value = strdup("");
     }
 
@@ -197,21 +197,21 @@ static AstNode *parse_primary(Parser *p) {
     Token t = current(p);
 
     if (match(p, TOK_INT_LIT)) {
-        AstNode *n = ast_new(NODE_INT_LIT, t.line);
+        AstNode *n = ast_new(NODE_INT_LIT, t);
         char *s = tok_str(t);
         n->as.int_lit.value = strtoll(s, NULL, 10);
         free(s);
         return n;
     }
     if (match(p, TOK_FLOAT_LIT)) {
-        AstNode *n = ast_new(NODE_FLOAT_LIT, t.line);
+        AstNode *n = ast_new(NODE_FLOAT_LIT, t);
         char *s = tok_str(t);
         n->as.float_lit.value = strtod(s, NULL);
         free(s);
         return n;
     }
     if (match(p, TOK_STR_LIT)) {
-        AstNode *n = ast_new(NODE_STR_LIT, t.line);
+        AstNode *n = ast_new(NODE_STR_LIT, t);
         n->as.str_lit.value = tok_str_value(t);
         return n;
     }
@@ -219,12 +219,12 @@ static AstNode *parse_primary(Parser *p) {
         return parse_fstring(p, t);
     }
     if (match(p, TOK_TRUE)) {
-        AstNode *n = ast_new(NODE_BOOL_LIT, t.line);
+        AstNode *n = ast_new(NODE_BOOL_LIT, t);
         n->as.bool_lit.value = true;
         return n;
     }
     if (match(p, TOK_FALSE)) {
-        AstNode *n = ast_new(NODE_BOOL_LIT, t.line);
+        AstNode *n = ast_new(NODE_BOOL_LIT, t);
         n->as.bool_lit.value = false;
         return n;
     }
@@ -233,7 +233,7 @@ static AstNode *parse_primary(Parser *p) {
         expect(p, TOK_LPAREN, "expected '(' after Ok");
         AstNode *val = parse_expr(p);
         expect(p, TOK_RPAREN, "expected ')' after Ok value");
-        AstNode *n = ast_new(NODE_OK_EXPR, t.line);
+        AstNode *n = ast_new(NODE_OK_EXPR, t);
         n->as.result_expr.value = val;
         return n;
     }
@@ -242,7 +242,7 @@ static AstNode *parse_primary(Parser *p) {
         expect(p, TOK_LPAREN, "expected '(' after Err");
         AstNode *val = parse_expr(p);
         expect(p, TOK_RPAREN, "expected ')' after Err value");
-        AstNode *n = ast_new(NODE_ERR_EXPR, t.line);
+        AstNode *n = ast_new(NODE_ERR_EXPR, t);
         n->as.result_expr.value = val;
         return n;
     }
@@ -272,7 +272,7 @@ static AstNode *parse_primary(Parser *p) {
                     }
                     expect(p, TOK_RPAREN, "expected ')' after enum args");
                 }
-                AstNode *n = ast_new(NODE_ENUM_INIT, t.line);
+                AstNode *n = ast_new(NODE_ENUM_INIT, t);
                 n->as.enum_init.enum_name = name;
                 n->as.enum_init.variant_name = variant;
                 n->as.enum_init.args = args;
@@ -290,7 +290,7 @@ static AstNode *parse_primary(Parser *p) {
                 advance_tok(p);
                 if (check(p, TOK_COLON)) {
                     p->pos = saved + 1;
-                    AstNode *n = ast_new(NODE_STRUCT_LIT, t.line);
+                    AstNode *n = ast_new(NODE_STRUCT_LIT, t);
                     n->as.struct_lit.name = name;
                     int cap = 4, count = 0;
                     FieldInit *fields = malloc(sizeof(FieldInit) * (size_t)cap);
@@ -315,12 +315,12 @@ static AstNode *parse_primary(Parser *p) {
             }
             p->pos = saved;
         }
-        AstNode *n = ast_new(NODE_IDENT, t.line);
+        AstNode *n = ast_new(NODE_IDENT, t);
         n->as.ident.name = name;
         return n;
     }
     if (match(p, TOK_LBRACKET)) {
-        AstNode *n = ast_new(NODE_ARRAY_LIT, t.line);
+        AstNode *n = ast_new(NODE_ARRAY_LIT, t);
         int cap = 4, count = 0;
         AstNode **elems = malloc(sizeof(AstNode *) * (size_t)cap);
         if (!check(p, TOK_RBRACKET)) {
@@ -344,14 +344,13 @@ static AstNode *parse_primary(Parser *p) {
     }
 
     error_at(p, t, "expected expression");
-    return ast_new(NODE_INT_LIT, t.line);
+    return ast_new(NODE_INT_LIT, t);
 }
 
 static AstNode *parse_call(Parser *p) {
     AstNode *expr = parse_primary(p);
     while (true) {
         if (match(p, TOK_LPAREN)) {
-            int line = previous(p).line;
             int cap = 4, count = 0;
             AstNode **args = malloc(sizeof(AstNode *) * (size_t)cap);
             if (!check(p, TOK_RPAREN)) {
@@ -364,21 +363,21 @@ static AstNode *parse_call(Parser *p) {
                 } while (match(p, TOK_COMMA));
             }
             expect(p, TOK_RPAREN, "expected ')' after arguments");
-            AstNode *call = ast_new(NODE_CALL, line);
+            AstNode *call = ast_new(NODE_CALL, previous(p));
             call->as.call.callee = expr;
             call->as.call.args = args;
             call->as.call.arg_count = count;
             expr = call;
         } else if (match(p, TOK_DOT)) {
             Token field = expect(p, TOK_IDENT, "expected field name after '.'");
-            AstNode *access = ast_new(NODE_FIELD_ACCESS, field.line);
+            AstNode *access = ast_new(NODE_FIELD_ACCESS, field);
             access->as.field_access.object = expr;
             access->as.field_access.field = tok_str(field);
             expr = access;
         } else if (match(p, TOK_LBRACKET)) {
             AstNode *index = parse_expr(p);
             expect(p, TOK_RBRACKET, "expected ']' after index");
-            AstNode *idx = ast_new(NODE_INDEX, previous(p).line);
+            AstNode *idx = ast_new(NODE_INDEX, previous(p));
             idx->as.index_expr.object = expr;
             idx->as.index_expr.index = index;
             expr = idx;
@@ -393,7 +392,7 @@ static AstNode *parse_unary(Parser *p) {
     if (match(p, TOK_NOT) || match(p, TOK_MINUS)) {
         Token op = previous(p);
         AstNode *operand = parse_unary(p);
-        AstNode *n = ast_new(NODE_UNARY, op.line);
+        AstNode *n = ast_new(NODE_UNARY, op);
         n->as.unary.op = op.type;
         n->as.unary.operand = operand;
         return n;
@@ -409,7 +408,7 @@ static AstNode *parse_binary(Parser *p, AstNode *(*sub)(Parser *), int n_ops, co
             if (match(p, ops[i])) {
                 Token op = previous(p);
                 AstNode *right = sub(p);
-                AstNode *bin = ast_new(NODE_BINARY, op.line);
+                AstNode *bin = ast_new(NODE_BINARY, op);
                 bin->as.binary.left = left;
                 bin->as.binary.op = op.type;
                 bin->as.binary.right = right;
@@ -460,9 +459,8 @@ static AstNode *parse_expr(Parser *p) {
 // ---- Statement parsing ----
 
 static AstNode *parse_block(Parser *p) {
-    int line = current(p).line;
     expect(p, TOK_LBRACE, "expected '{'");
-    AstNode *block = ast_new(NODE_BLOCK, line);
+    AstNode *block = ast_new(NODE_BLOCK, current(p));
     int cap = 8, count = 0;
     AstNode **stmts = malloc(sizeof(AstNode *) * (size_t)cap);
     while (!check(p, TOK_RBRACE) && !at_end(p)) {
@@ -480,7 +478,6 @@ static AstNode *parse_block(Parser *p) {
 }
 
 static AstNode *parse_let(Parser *p) {
-    int line = current(p).line;
     expect(p, TOK_LET, "expected 'let'");
     bool is_mut = match(p, TOK_MUT);
     Token name = expect(p, TOK_IDENT, "expected variable name");
@@ -489,7 +486,7 @@ static AstNode *parse_let(Parser *p) {
     expect(p, TOK_ASSIGN, "expected '=' in let statement");
     AstNode *init = parse_expr(p);
     expect(p, TOK_SEMICOLON, "expected ';' after let statement");
-    AstNode *n = ast_new(NODE_LET_STMT, line);
+    AstNode *n = ast_new(NODE_LET_STMT, current(p));
     n->as.let_stmt.name = tok_str(name);
     n->as.let_stmt.is_mut = is_mut;
     n->as.let_stmt.type = type;
@@ -498,7 +495,6 @@ static AstNode *parse_let(Parser *p) {
 }
 
 static AstNode *parse_if(Parser *p) {
-    int line = current(p).line;
     expect(p, TOK_IF, "expected 'if'");
     AstNode *cond = parse_expr(p);
     AstNode *then_block = parse_block(p);
@@ -510,7 +506,7 @@ static AstNode *parse_if(Parser *p) {
             else_branch = parse_block(p);
         }
     }
-    AstNode *n = ast_new(NODE_IF_STMT, line);
+    AstNode *n = ast_new(NODE_IF_STMT, current(p));
     n->as.if_stmt.condition = cond;
     n->as.if_stmt.then_block = then_block;
     n->as.if_stmt.else_branch = else_branch;
@@ -518,18 +514,16 @@ static AstNode *parse_if(Parser *p) {
 }
 
 static AstNode *parse_while(Parser *p) {
-    int line = current(p).line;
     expect(p, TOK_WHILE, "expected 'while'");
     AstNode *cond = parse_expr(p);
     AstNode *body = parse_block(p);
-    AstNode *n = ast_new(NODE_WHILE_STMT, line);
+    AstNode *n = ast_new(NODE_WHILE_STMT, current(p));
     n->as.while_stmt.condition = cond;
     n->as.while_stmt.body = body;
     return n;
 }
 
 static AstNode *parse_for(Parser *p) {
-    int line = current(p).line;
     expect(p, TOK_FOR, "expected 'for'");
     Token var = expect(p, TOK_IDENT, "expected loop variable");
     expect(p, TOK_IN, "expected 'in'");
@@ -541,7 +535,7 @@ static AstNode *parse_for(Parser *p) {
         if (!inclusive) expect(p, TOK_DOTDOT, "expected '..'");
         AstNode *end = parse_expr(p);
         AstNode *body = parse_block(p);
-        AstNode *n = ast_new(NODE_FOR_STMT, line);
+        AstNode *n = ast_new(NODE_FOR_STMT, current(p));
         n->as.for_stmt.var_name = tok_str(var);
         n->as.for_stmt.start = expr;
         n->as.for_stmt.end = end;
@@ -554,7 +548,7 @@ static AstNode *parse_for(Parser *p) {
 
     // For-each: for item in iterable { ... }
     AstNode *body = parse_block(p);
-    AstNode *n = ast_new(NODE_FOR_STMT, line);
+    AstNode *n = ast_new(NODE_FOR_STMT, current(p));
     n->as.for_stmt.var_name = tok_str(var);
     n->as.for_stmt.start = NULL;
     n->as.for_stmt.end = NULL;
@@ -566,14 +560,13 @@ static AstNode *parse_for(Parser *p) {
 }
 
 static AstNode *parse_return(Parser *p) {
-    int line = current(p).line;
     expect(p, TOK_RETURN, "expected 'return'");
     AstNode *val = NULL;
     if (!check(p, TOK_SEMICOLON)) {
         val = parse_expr(p);
     }
     expect(p, TOK_SEMICOLON, "expected ';' after return");
-    AstNode *n = ast_new(NODE_RETURN_STMT, line);
+    AstNode *n = ast_new(NODE_RETURN_STMT, current(p));
     n->as.return_stmt.value = val;
     return n;
 }
@@ -588,7 +581,6 @@ static bool is_assign_op(TokenType t) {
 }
 
 static AstNode *parse_match(Parser *p) {
-    int line = current(p).line;
     expect(p, TOK_MATCH, "expected 'match'");
     AstNode *target = parse_expr(p);
     expect(p, TOK_LBRACE, "expected '{' after match target");
@@ -634,7 +626,7 @@ static AstNode *parse_match(Parser *p) {
     }
     expect(p, TOK_RBRACE, "expected '}' after match arms");
 
-    AstNode *n = ast_new(NODE_MATCH, line);
+    AstNode *n = ast_new(NODE_MATCH, current(p));
     n->as.match_stmt.target = target;
     n->as.match_stmt.arms = arms;
     n->as.match_stmt.arm_count = count;
@@ -649,14 +641,12 @@ static AstNode *parse_statement(Parser *p) {
     if (check(p, TOK_MATCH)) return parse_match(p);
     if (check(p, TOK_RETURN)) return parse_return(p);
     if (match(p, TOK_BREAK)) {
-        int line = previous(p).line;
         expect(p, TOK_SEMICOLON, "expected ';' after break");
-        return ast_new(NODE_BREAK_STMT, line);
+        return ast_new(NODE_BREAK_STMT, previous(p));
     }
     if (match(p, TOK_CONTINUE)) {
-        int line = previous(p).line;
         expect(p, TOK_SEMICOLON, "expected ';' after continue");
-        return ast_new(NODE_CONTINUE_STMT, line);
+        return ast_new(NODE_CONTINUE_STMT, previous(p));
     }
 
     AstNode *expr = parse_expr(p);
@@ -664,7 +654,7 @@ static AstNode *parse_statement(Parser *p) {
         Token op = advance_tok(p);
         AstNode *value = parse_expr(p);
         expect(p, TOK_SEMICOLON, "expected ';' after assignment");
-        AstNode *n = ast_new(NODE_ASSIGN_STMT, op.line);
+        AstNode *n = ast_new(NODE_ASSIGN_STMT, op);
         n->as.assign_stmt.target = expr;
         n->as.assign_stmt.op = op.type;
         n->as.assign_stmt.value = value;
@@ -672,7 +662,7 @@ static AstNode *parse_statement(Parser *p) {
     }
 
     expect(p, TOK_SEMICOLON, "expected ';' after expression");
-    AstNode *n = ast_new(NODE_EXPR_STMT, expr->line);
+    AstNode *n = ast_new(NODE_EXPR_STMT, expr->tok);
     n->as.expr_stmt.expr = expr;
     return n;
 }
@@ -680,7 +670,6 @@ static AstNode *parse_statement(Parser *p) {
 // ---- Top-level parsing ----
 
 static AstNode *parse_fn_decl(Parser *p) {
-    int line = current(p).line;
     expect(p, TOK_FN, "expected 'fn'");
     Token name = expect(p, TOK_IDENT, "expected function name");
     expect(p, TOK_LPAREN, "expected '('");
@@ -712,7 +701,7 @@ static AstNode *parse_fn_decl(Parser *p) {
 
     AstNode *body = parse_block(p);
 
-    AstNode *n = ast_new(NODE_FN_DECL, line);
+    AstNode *n = ast_new(NODE_FN_DECL, current(p));
     n->as.fn_decl.name = tok_str(name);
     n->as.fn_decl.params = params;
     n->as.fn_decl.param_count = count;
@@ -722,7 +711,6 @@ static AstNode *parse_fn_decl(Parser *p) {
 }
 
 static AstNode *parse_struct_decl(Parser *p) {
-    int line = current(p).line;
     expect(p, TOK_STRUCT, "expected 'struct'");
     Token name = expect(p, TOK_IDENT, "expected struct name");
     expect(p, TOK_LBRACE, "expected '{'");
@@ -744,7 +732,7 @@ static AstNode *parse_struct_decl(Parser *p) {
     }
     expect(p, TOK_RBRACE, "expected '}'");
 
-    AstNode *n = ast_new(NODE_STRUCT_DECL, line);
+    AstNode *n = ast_new(NODE_STRUCT_DECL, current(p));
     n->as.struct_decl.name = tok_str(name);
     n->as.struct_decl.fields = fields;
     n->as.struct_decl.field_count = count;
@@ -752,7 +740,6 @@ static AstNode *parse_struct_decl(Parser *p) {
 }
 
 static AstNode *parse_enum_decl(Parser *p) {
-    int line = current(p).line;
     expect(p, TOK_ENUM, "expected 'enum'");
     Token name = expect(p, TOK_IDENT, "expected enum name");
     expect(p, TOK_LBRACE, "expected '{'");
@@ -797,7 +784,7 @@ static AstNode *parse_enum_decl(Parser *p) {
     }
     expect(p, TOK_RBRACE, "expected '}'");
 
-    AstNode *n = ast_new(NODE_ENUM_DECL, line);
+    AstNode *n = ast_new(NODE_ENUM_DECL, current(p));
     n->as.enum_decl.name = tok_str(name);
     n->as.enum_decl.variants = variants;
     n->as.enum_decl.variant_count = count;
@@ -805,11 +792,10 @@ static AstNode *parse_enum_decl(Parser *p) {
 }
 
 static AstNode *parse_import(Parser *p) {
-    int line = current(p).line;
     expect(p, TOK_IMPORT, "expected 'import'");
     Token path = expect(p, TOK_STR_LIT, "expected module path string");
     expect(p, TOK_SEMICOLON, "expected ';' after import");
-    AstNode *n = ast_new(NODE_IMPORT, line);
+    AstNode *n = ast_new(NODE_IMPORT, current(p));
     n->as.import_decl.path = tok_str_value(path);
     return n;
 }
@@ -823,7 +809,7 @@ static AstNode *parse_declaration(Parser *p) {
 }
 
 AstNode *parser_parse(Parser *p) {
-    AstNode *program = ast_new(NODE_PROGRAM, 1);
+    AstNode *program = ast_new(NODE_PROGRAM, current(p));
     int cap = 16, count = 0;
     AstNode **decls = malloc(sizeof(AstNode *) * (size_t)cap);
 

--- a/compiler/src/sema.c
+++ b/compiler/src/sema.c
@@ -3,6 +3,7 @@
 #endif
 
 #include "sema.h"
+#include "error.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -37,6 +38,7 @@ typedef struct Scope {
 typedef struct {
     Scope *current;
     AstType *current_fn_return;
+    const char *filename;
     int errors;
     int loop_depth;
 } Sema;
@@ -84,14 +86,16 @@ static Symbol *scope_add(Scope *s, const char *name) {
 
 // ---- Error reporting ----
 
-static void sema_error(Sema *ctx, int line, const char *fmt, ...) {
-    ctx->errors++;
-    fprintf(stderr, "[line %d] Error: ", line);
+static void sema_error(Sema *ctx, Token *t, const char *fmt, ...) {
+    char msg[1024];
+
     va_list args;
     va_start(args, fmt);
-    vfprintf(stderr, fmt, args);
+    vsnprintf(msg, sizeof(msg), fmt, args);
     va_end(args);
-    fprintf(stderr, "\n");
+
+    report_error(ctx->filename, t, msg);
+    ctx->errors++;
 }
 
 // ---- Forward declarations ----
@@ -125,7 +129,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
     case NODE_IDENT: {
         Symbol *sym = scope_lookup(ctx->current, node->as.ident.name);
         if (!sym) {
-            sema_error(ctx, node->line, "undefined variable '%s'", node->as.ident.name);
+            sema_error(ctx, &node->tok, "undefined variable '%s'", node->as.ident.name);
             return set_type(node, ast_type_simple(TYPE_VOID));
         }
         return set_type(node, ast_type_clone(sym->type));
@@ -141,7 +145,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
         if (op == TOK_EQ || op == TOK_NEQ || op == TOK_LT || op == TOK_GT ||
             op == TOK_LTE || op == TOK_GTE) {
             if (!ast_types_equal(lt, rt)) {
-                sema_error(ctx, node->line, "cannot compare '%s' with '%s'",
+                sema_error(ctx, &node->tok, "cannot compare '%s' with '%s'",
                            ast_type_str(lt), ast_type_str(rt));
             }
             return set_type(node, ast_type_simple(TYPE_BOOL));
@@ -149,11 +153,11 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
 
         if (op == TOK_AND || op == TOK_OR) {
             if (lt->kind != TYPE_BOOL) {
-                sema_error(ctx, node->line, "left operand of '%s' must be bool, got '%s'",
+                sema_error(ctx, &node->tok, "left operand of '%s' must be bool, got '%s'",
                            token_type_name(op), ast_type_str(lt));
             }
             if (rt->kind != TYPE_BOOL) {
-                sema_error(ctx, node->line, "right operand of '%s' must be bool, got '%s'",
+                sema_error(ctx, &node->tok, "right operand of '%s' must be bool, got '%s'",
                            token_type_name(op), ast_type_str(rt));
             }
             return set_type(node, ast_type_simple(TYPE_BOOL));
@@ -166,12 +170,12 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
         if (op == TOK_PLUS || op == TOK_MINUS || op == TOK_STAR ||
             op == TOK_SLASH || op == TOK_PERCENT) {
             if (!ast_types_equal(lt, rt)) {
-                sema_error(ctx, node->line, "mismatched types in '%s': '%s' and '%s'",
+                sema_error(ctx, &node->tok, "mismatched types in '%s': '%s' and '%s'",
                            token_type_name(op), ast_type_str(lt), ast_type_str(rt));
                 return set_type(node, ast_type_clone(lt));
             }
             if (lt->kind != TYPE_INT && lt->kind != TYPE_FLOAT) {
-                sema_error(ctx, node->line, "operator '%s' requires numeric types, got '%s'",
+                sema_error(ctx, &node->tok, "operator '%s' requires numeric types, got '%s'",
                            token_type_name(op), ast_type_str(lt));
             }
             return set_type(node, ast_type_clone(lt));
@@ -185,13 +189,13 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
         if (!t) return set_type(node, ast_type_simple(TYPE_VOID));
         if (node->as.unary.op == TOK_NOT) {
             if (t->kind != TYPE_BOOL) {
-                sema_error(ctx, node->line, "'!' requires bool, got '%s'", ast_type_str(t));
+                sema_error(ctx, &node->tok, "'!' requires bool, got '%s'", ast_type_str(t));
             }
             return set_type(node, ast_type_simple(TYPE_BOOL));
         }
         if (node->as.unary.op == TOK_MINUS) {
             if (t->kind != TYPE_INT && t->kind != TYPE_FLOAT) {
-                sema_error(ctx, node->line, "unary '-' requires numeric type, got '%s'", ast_type_str(t));
+                sema_error(ctx, &node->tok, "unary '-' requires numeric type, got '%s'", ast_type_str(t));
             }
             return set_type(node, ast_type_clone(t));
         }
@@ -226,14 +230,14 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
                     node->as.call.arg_count = new_count;
                     // Fall through to normal call checking below
                 } else {
-                    sema_error(ctx, node->line, "no method '%s' on type '%s'",
+                    sema_error(ctx, &node->tok, "no method '%s' on type '%s'",
                                method, obj_type->name);
                     for (int i = 0; i < node->as.call.arg_count; i++)
                         check_expr(ctx, node->as.call.args[i]);
                     return set_type(node, ast_type_simple(TYPE_VOID));
                 }
             } else {
-                sema_error(ctx, node->line, "method call on non-struct type '%s'",
+                sema_error(ctx, &node->tok, "method call on non-struct type '%s'",
                            ast_type_str(obj_type));
                 for (int i = 0; i < node->as.call.arg_count; i++)
                     check_expr(ctx, node->as.call.args[i]);
@@ -242,7 +246,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
         }
 
         if (node->as.call.callee->kind != NODE_IDENT) {
-            sema_error(ctx, node->line, "callee must be a function name");
+            sema_error(ctx, &node->tok, "callee must be a function name");
             for (int i = 0; i < node->as.call.arg_count; i++)
                 check_expr(ctx, node->as.call.args[i]);
             return set_type(node, ast_type_simple(TYPE_VOID));
@@ -251,20 +255,20 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
         const char *fn_name = node->as.call.callee->as.ident.name;
         Symbol *sym = scope_lookup(ctx->current, fn_name);
         if (!sym) {
-            sema_error(ctx, node->line, "undefined function '%s'", fn_name);
+            sema_error(ctx, &node->tok, "undefined function '%s'", fn_name);
             for (int i = 0; i < node->as.call.arg_count; i++)
                 check_expr(ctx, node->as.call.args[i]);
             return set_type(node, ast_type_simple(TYPE_VOID));
         }
         if (!sym->is_fn) {
-            sema_error(ctx, node->line, "'%s' is not a function", fn_name);
+            sema_error(ctx, &node->tok, "'%s' is not a function", fn_name);
             for (int i = 0; i < node->as.call.arg_count; i++)
                 check_expr(ctx, node->as.call.args[i]);
             return set_type(node, ast_type_simple(TYPE_VOID));
         }
 
         if (sym->param_count >= 0 && node->as.call.arg_count != sym->param_count) {
-            sema_error(ctx, node->line, "'%s' expects %d arguments, got %d",
+            sema_error(ctx, &node->tok, "'%s' expects %d arguments, got %d",
                        fn_name, sym->param_count, node->as.call.arg_count);
         }
 
@@ -273,7 +277,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
             if (sym->param_count > 0 && i < sym->param_count && sym->params) {
                 if (!ast_types_equal(at, sym->params[i].type)) {
                     if (sym->params[i].type && sym->params[i].type->kind != TYPE_VOID) {
-                        sema_error(ctx, node->line,
+                        sema_error(ctx, &node->tok,
                                    "argument %d of '%s': expected '%s', got '%s'",
                                    i + 1, fn_name,
                                    ast_type_str(sym->params[i].type),
@@ -305,13 +309,13 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
     case NODE_FIELD_ACCESS: {
         AstType *obj_type = check_expr(ctx, node->as.field_access.object);
         if (!obj_type || obj_type->kind != TYPE_NAMED) {
-            sema_error(ctx, node->line, "field access on non-struct type '%s'",
+            sema_error(ctx, &node->tok, "field access on non-struct type '%s'",
                        ast_type_str(obj_type));
             return set_type(node, ast_type_simple(TYPE_VOID));
         }
         Symbol *st = scope_lookup(ctx->current, obj_type->name);
         if (!st || !st->is_struct) {
-            sema_error(ctx, node->line, "unknown struct '%s'", obj_type->name);
+            sema_error(ctx, &node->tok, "unknown struct '%s'", obj_type->name);
             return set_type(node, ast_type_simple(TYPE_VOID));
         }
         for (int i = 0; i < st->field_count; i++) {
@@ -319,7 +323,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
                 return set_type(node, ast_type_clone(st->fields[i].type));
             }
         }
-        sema_error(ctx, node->line, "struct '%s' has no field '%s'",
+        sema_error(ctx, &node->tok, "struct '%s' has no field '%s'",
                    obj_type->name, node->as.field_access.field);
         return set_type(node, ast_type_simple(TYPE_VOID));
     }
@@ -328,10 +332,10 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
         AstType *obj_type = check_expr(ctx, node->as.index_expr.object);
         AstType *idx_type = check_expr(ctx, node->as.index_expr.index);
         if (idx_type && idx_type->kind != TYPE_INT) {
-            sema_error(ctx, node->line, "array index must be int, got '%s'", ast_type_str(idx_type));
+            sema_error(ctx, &node->tok, "array index must be int, got '%s'", ast_type_str(idx_type));
         }
         if (!obj_type || obj_type->kind != TYPE_ARRAY) {
-            sema_error(ctx, node->line, "index operator on non-array type '%s'", ast_type_str(obj_type));
+            sema_error(ctx, &node->tok, "index operator on non-array type '%s'", ast_type_str(obj_type));
             return set_type(node, ast_type_simple(TYPE_VOID));
         }
         return set_type(node, ast_type_clone(obj_type->element));
@@ -344,7 +348,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
             if (i == 0) {
                 elem_type = t;
             } else if (!ast_types_equal(elem_type, t)) {
-                sema_error(ctx, node->line, "array element type mismatch: expected '%s', got '%s'",
+                sema_error(ctx, &node->tok, "array element type mismatch: expected '%s', got '%s'",
                            ast_type_str(elem_type), ast_type_str(t));
             }
         }
@@ -356,13 +360,13 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
         const char *name = node->as.struct_lit.name;
         Symbol *st = scope_lookup(ctx->current, name);
         if (!st || !st->is_struct) {
-            sema_error(ctx, node->line, "unknown struct '%s'", name);
+            sema_error(ctx, &node->tok, "unknown struct '%s'", name);
             for (int i = 0; i < node->as.struct_lit.field_count; i++)
                 check_expr(ctx, node->as.struct_lit.fields[i].value);
             return set_type(node, ast_type_simple(TYPE_VOID));
         }
         if (node->as.struct_lit.field_count != st->field_count) {
-            sema_error(ctx, node->line, "struct '%s' has %d fields, got %d",
+            sema_error(ctx, &node->tok, "struct '%s' has %d fields, got %d",
                        name, st->field_count, node->as.struct_lit.field_count);
         }
         for (int i = 0; i < node->as.struct_lit.field_count; i++) {
@@ -372,7 +376,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
                 if (strcmp(node->as.struct_lit.fields[i].name, st->fields[j].name) == 0) {
                     found = true;
                     if (!ast_types_equal(vt, st->fields[j].type)) {
-                        sema_error(ctx, node->line, "field '%s': expected '%s', got '%s'",
+                        sema_error(ctx, &node->tok, "field '%s': expected '%s', got '%s'",
                                    st->fields[j].name,
                                    ast_type_str(st->fields[j].type),
                                    ast_type_str(vt));
@@ -381,7 +385,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
                 }
             }
             if (!found) {
-                sema_error(ctx, node->line, "struct '%s' has no field '%s'",
+                sema_error(ctx, &node->tok, "struct '%s' has no field '%s'",
                            name, node->as.struct_lit.fields[i].name);
             }
         }
@@ -392,7 +396,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
         const char *ename = node->as.enum_init.enum_name;
         Symbol *sym = scope_lookup(ctx->current, ename);
         if (!sym || !sym->is_enum) {
-            sema_error(ctx, node->line, "unknown enum '%s'", ename);
+            sema_error(ctx, &node->tok, "unknown enum '%s'", ename);
             for (int i = 0; i < node->as.enum_init.arg_count; i++)
                 check_expr(ctx, node->as.enum_init.args[i]);
             return set_type(node, ast_type_simple(TYPE_VOID));
@@ -407,19 +411,19 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
             }
         }
         if (!variant) {
-            sema_error(ctx, node->line, "enum '%s' has no variant '%s'", ename, vname);
+            sema_error(ctx, &node->tok, "enum '%s' has no variant '%s'", ename, vname);
             for (int i = 0; i < node->as.enum_init.arg_count; i++)
                 check_expr(ctx, node->as.enum_init.args[i]);
             return set_type(node, ast_type_simple(TYPE_VOID));
         }
         if (node->as.enum_init.arg_count != variant->field_count) {
-            sema_error(ctx, node->line, "variant '%s.%s' expects %d args, got %d",
+            sema_error(ctx, &node->tok, "variant '%s.%s' expects %d args, got %d",
                        ename, vname, variant->field_count, node->as.enum_init.arg_count);
         }
         for (int i = 0; i < node->as.enum_init.arg_count && i < variant->field_count; i++) {
             AstType *at = check_expr(ctx, node->as.enum_init.args[i]);
             if (!ast_types_equal(at, variant->fields[i].type)) {
-                sema_error(ctx, node->line, "variant '%s.%s' arg %d: expected '%s', got '%s'",
+                sema_error(ctx, &node->tok, "variant '%s.%s' arg %d: expected '%s', got '%s'",
                            ename, vname, i + 1,
                            ast_type_str(variant->fields[i].type), ast_type_str(at));
             }
@@ -460,13 +464,13 @@ static void check_stmt(Sema *ctx, AstNode *node) {
             if (!(decl_type->kind == TYPE_RESULT &&
                   (node->as.let_stmt.init->kind == NODE_OK_EXPR ||
                    node->as.let_stmt.init->kind == NODE_ERR_EXPR))) {
-                sema_error(ctx, node->line, "cannot assign '%s' to variable of type '%s'",
+                sema_error(ctx, &node->tok, "cannot assign '%s' to variable of type '%s'",
                            ast_type_str(init_type), ast_type_str(decl_type));
             }
         }
 
         if (scope_lookup_local(ctx->current, node->as.let_stmt.name)) {
-            sema_error(ctx, node->line, "variable '%s' already declared in this scope",
+            sema_error(ctx, &node->tok, "variable '%s' already declared in this scope",
                        node->as.let_stmt.name);
         }
 
@@ -483,13 +487,13 @@ static void check_stmt(Sema *ctx, AstNode *node) {
         if (node->as.assign_stmt.target->kind == NODE_IDENT) {
             Symbol *sym = scope_lookup(ctx->current, node->as.assign_stmt.target->as.ident.name);
             if (sym && !sym->is_mut && !sym->is_fn) {
-                sema_error(ctx, node->line, "cannot assign to immutable variable '%s'",
+                sema_error(ctx, &node->tok, "cannot assign to immutable variable '%s'",
                            node->as.assign_stmt.target->as.ident.name);
             }
         }
 
         if (target_type && val_type && !ast_types_equal(target_type, val_type)) {
-            sema_error(ctx, node->line, "cannot assign '%s' to '%s'",
+            sema_error(ctx, &node->tok, "cannot assign '%s' to '%s'",
                        ast_type_str(val_type), ast_type_str(target_type));
         }
         break;
@@ -498,7 +502,7 @@ static void check_stmt(Sema *ctx, AstNode *node) {
     case NODE_IF_STMT: {
         AstType *cond = check_expr(ctx, node->as.if_stmt.condition);
         if (cond && cond->kind != TYPE_BOOL) {
-            sema_error(ctx, node->line, "if condition must be bool, got '%s'", ast_type_str(cond));
+            sema_error(ctx, &node->tok, "if condition must be bool, got '%s'", ast_type_str(cond));
         }
         check_block(ctx, node->as.if_stmt.then_block);
         if (node->as.if_stmt.else_branch) {
@@ -514,7 +518,7 @@ static void check_stmt(Sema *ctx, AstNode *node) {
     case NODE_WHILE_STMT: {
         AstType *cond = check_expr(ctx, node->as.while_stmt.condition);
         if (cond && cond->kind != TYPE_BOOL) {
-            sema_error(ctx, node->line, "while condition must be bool, got '%s'", ast_type_str(cond));
+            sema_error(ctx, &node->tok, "while condition must be bool, got '%s'", ast_type_str(cond));
         }
         ctx->loop_depth++;
         check_block(ctx, node->as.while_stmt.body);
@@ -527,7 +531,7 @@ static void check_stmt(Sema *ctx, AstNode *node) {
             // For-each over array
             AstType *iter_type = check_expr(ctx, node->as.for_stmt.iterable);
             if (!iter_type || iter_type->kind != TYPE_ARRAY) {
-                sema_error(ctx, node->line, "for-each requires array type, got '%s'",
+                sema_error(ctx, &node->tok, "for-each requires array type, got '%s'",
                            ast_type_str(iter_type));
             }
             AstType *elem_type = (iter_type && iter_type->kind == TYPE_ARRAY && iter_type->element)
@@ -554,10 +558,10 @@ static void check_stmt(Sema *ctx, AstNode *node) {
             AstType *start = check_expr(ctx, node->as.for_stmt.start);
             AstType *end = check_expr(ctx, node->as.for_stmt.end);
             if (start && start->kind != TYPE_INT) {
-                sema_error(ctx, node->line, "for range start must be int, got '%s'", ast_type_str(start));
+                sema_error(ctx, &node->tok, "for range start must be int, got '%s'", ast_type_str(start));
             }
             if (end && end->kind != TYPE_INT) {
-                sema_error(ctx, node->line, "for range end must be int, got '%s'", ast_type_str(end));
+                sema_error(ctx, &node->tok, "for range end must be int, got '%s'", ast_type_str(end));
             }
 
             Scope *body_scope = scope_new(ctx->current);
@@ -588,13 +592,13 @@ static void check_stmt(Sema *ctx, AstNode *node) {
                 if (!(ctx->current_fn_return->kind == TYPE_RESULT &&
                       (node->as.return_stmt.value->kind == NODE_OK_EXPR ||
                        node->as.return_stmt.value->kind == NODE_ERR_EXPR))) {
-                    sema_error(ctx, node->line, "return type mismatch: expected '%s', got '%s'",
+                    sema_error(ctx, &node->tok, "return type mismatch: expected '%s', got '%s'",
                                ast_type_str(ctx->current_fn_return), ast_type_str(t));
                 }
             }
         } else {
             if (ctx->current_fn_return && ctx->current_fn_return->kind != TYPE_VOID) {
-                sema_error(ctx, node->line, "function expects return value of type '%s'",
+                sema_error(ctx, &node->tok, "function expects return value of type '%s'",
                            ast_type_str(ctx->current_fn_return));
             }
         }
@@ -603,13 +607,13 @@ static void check_stmt(Sema *ctx, AstNode *node) {
 
     case NODE_BREAK_STMT:
         if (ctx->loop_depth == 0) {
-            sema_error(ctx, node->line, "break outside of loop");
+            sema_error(ctx, &node->tok, "break outside of loop");
         }
         break;
 
     case NODE_CONTINUE_STMT:
         if (ctx->loop_depth == 0) {
-            sema_error(ctx, node->line, "continue outside of loop");
+            sema_error(ctx, &node->tok, "continue outside of loop");
         }
         break;
 
@@ -624,13 +628,13 @@ static void check_stmt(Sema *ctx, AstNode *node) {
     case NODE_MATCH: {
         AstType *target_type = check_expr(ctx, node->as.match_stmt.target);
         if (!target_type || target_type->kind != TYPE_NAMED) {
-            sema_error(ctx, node->line, "match target must be an enum type, got '%s'",
+            sema_error(ctx, &node->tok, "match target must be an enum type, got '%s'",
                        ast_type_str(target_type));
             break;
         }
         Symbol *enum_sym = scope_lookup(ctx->current, target_type->name);
         if (!enum_sym || !enum_sym->is_enum) {
-            sema_error(ctx, node->line, "match target type '%s' is not an enum", target_type->name);
+            sema_error(ctx, &node->tok, "match target type '%s' is not an enum", target_type->name);
             break;
         }
 
@@ -645,12 +649,12 @@ static void check_stmt(Sema *ctx, AstNode *node) {
                 }
             }
             if (!variant) {
-                sema_error(ctx, node->line, "enum '%s' has no variant '%s'",
+                sema_error(ctx, &node->tok, "enum '%s' has no variant '%s'",
                            target_type->name, arm->variant_name);
                 continue;
             }
             if (arm->binding_count != variant->field_count) {
-                sema_error(ctx, node->line, "variant '%s' has %d fields, got %d bindings",
+                sema_error(ctx, &node->tok, "variant '%s' has %d fields, got %d bindings",
                            arm->variant_name, variant->field_count, arm->binding_count);
             }
 
@@ -769,9 +773,10 @@ static void register_builtins(Scope *global) {
 
 // ---- Top-level ----
 
-bool sema_analyze(AstNode *program) {
+bool sema_analyze(AstNode *program, const char *filename) {
     Sema ctx = {0};
     Scope *global = scope_new(NULL);
+    ctx.filename = filename;
     ctx.current = global;
 
     register_builtins(global);
@@ -781,7 +786,7 @@ bool sema_analyze(AstNode *program) {
         AstNode *d = program->as.program.decls[i];
         if (d->kind == NODE_STRUCT_DECL) {
             if (scope_lookup_local(global, d->as.struct_decl.name)) {
-                sema_error(&ctx, d->line, "duplicate struct '%s'", d->as.struct_decl.name);
+                sema_error(&ctx, &d->tok, "duplicate struct '%s'", d->as.struct_decl.name);
                 continue;
             }
             Symbol *s = scope_add(global, d->as.struct_decl.name);
@@ -791,7 +796,7 @@ bool sema_analyze(AstNode *program) {
             s->type = ast_type_named(d->as.struct_decl.name);
         } else if (d->kind == NODE_ENUM_DECL) {
             if (scope_lookup_local(global, d->as.enum_decl.name)) {
-                sema_error(&ctx, d->line, "duplicate enum '%s'", d->as.enum_decl.name);
+                sema_error(&ctx, &d->tok, "duplicate enum '%s'", d->as.enum_decl.name);
                 continue;
             }
             Symbol *s = scope_add(global, d->as.enum_decl.name);
@@ -801,7 +806,7 @@ bool sema_analyze(AstNode *program) {
             s->type = ast_type_named(d->as.enum_decl.name);
         } else if (d->kind == NODE_FN_DECL) {
             if (scope_lookup_local(global, d->as.fn_decl.name)) {
-                sema_error(&ctx, d->line, "duplicate function '%s'", d->as.fn_decl.name);
+                sema_error(&ctx, &d->tok, "duplicate function '%s'", d->as.fn_decl.name);
                 continue;
             }
             Symbol *s = scope_add(global, d->as.fn_decl.name);

--- a/tests/invalid/parser/unclosed_brace.urus
+++ b/tests/invalid/parser/unclosed_brace.urus
@@ -1,0 +1,3 @@
+fn main(): void {
+    let x: [int] = [1,2,3 // <-- unclosed brace test
+}


### PR DESCRIPTION
Completed 1.1.0 roadmap (Better error message with source context)

Example:
<img width="562" height="549" alt="better-eror" src="https://github.com/user-attachments/assets/d0856696-6755-45c3-89c6-3fc79ca69f29" />