### PR TITLE
fix: added error handling for unknown function return type

### DIFF
--- a/compiler/src/sema.c
+++ b/compiler/src/sema.c
@@ -809,6 +809,12 @@ bool sema_analyze(AstNode *program, const char *filename) {
                 sema_error(&ctx, &d->tok, "duplicate function '%s'", d->as.fn_decl.name);
                 continue;
             }
+            else if (d->as.fn_decl.return_type->kind == TYPE_NAMED &&
+                    !scope_lookup(ctx.current, d->as.fn_decl.return_type->name)) {
+                sema_error(&ctx, &d->tok, "function '%s' has unknown return type '%s'", d->as.fn_decl.name,
+                           d->as.fn_decl.return_type->name);
+                continue;
+            }
             Symbol *s = scope_add(global, d->as.fn_decl.name);
             s->is_fn = true;
             s->params = d->as.fn_decl.params;

--- a/tests/invalid/unknown_function_return_type.urus
+++ b/tests/invalid/unknown_function_return_type.urus
@@ -1,0 +1,3 @@
+fn main(): voif { // <- void -> voif typo
+    let mut x: int = 15;
+}


### PR DESCRIPTION
## Description

Normally, in urus, if you had a function like example:
```urus
fn main(): voif { // <-- void typo
  // .. statement ..
}
```
Semantic wont detect this, and continues to compile this and generate hard-to-debug error.

Now, if you do that again in this version, you ill be show up with this:
```bash
$ urusc typo.urus
typo.urus:1: error: function 'main' has unknown return type 'voif'
````

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing code to break)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test update (i add invalid/unknown_function_return_type.urus)