### PR TITLE
fix: fix issues#16 (push method takes floats as integers)

### DIFF
--- a/compiler/include/ast.h
+++ b/compiler/include/ast.h
@@ -271,6 +271,7 @@ char *ast_strdup(const char *s, size_t len);
 // Type utilities
 AstType *ast_type_clone(AstType *t);
 bool ast_types_equal(AstType *a, AstType *b);
+bool ast_types_compatible(AstType *from, AstType *to); // check if its compatible (fair). Example: let x: float = 1;
 const char *ast_type_str(AstType *t); // returns static buffer (round-robin)
 
 // Debug printing

--- a/compiler/src/ast.c
+++ b/compiler/src/ast.c
@@ -95,6 +95,16 @@ bool ast_types_equal(AstType *a, AstType *b) {
     return true;
 }
 
+bool ast_types_compatible(AstType *from, AstType *to) {
+    if (!from || !to) return false;
+    if (ast_types_equal(from, to)) return true;
+    if (from->kind == TYPE_INT && to->kind == TYPE_FLOAT) return true;
+    if (from->kind == TYPE_ARRAY && to->kind == TYPE_ARRAY) {
+        if (from->element->kind == TYPE_INT && to->element->kind == TYPE_FLOAT) return true;
+    }
+    return false;
+}
+
 // Round-robin static buffers to avoid clobber in printf with multiple calls
 const char *ast_type_str(AstType *t) {
     static char bufs[4][256];

--- a/compiler/src/sema.c
+++ b/compiler/src/sema.c
@@ -398,6 +398,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
                            ast_type_str(elem_type), ast_type_str(t));
             }
         }
+        // NOTE: 'left = []' considered as INT type
         if (!elem_type) elem_type = ast_type_simple(TYPE_INT);
         return set_type(node, ast_type_array(ast_type_clone(elem_type)));
     }
@@ -505,7 +506,7 @@ static void check_stmt(Sema *ctx, AstNode *node) {
         AstType *init_type = check_expr(ctx, node->as.let_stmt.init);
         AstType *decl_type = node->as.let_stmt.type;
 
-        if (init_type && decl_type && !ast_types_equal(init_type, decl_type)) {
+        if (init_type && decl_type && (!ast_types_equal(init_type, decl_type) && !ast_types_compatible(init_type, decl_type))) {
             // Allow Result type coercion (Ok/Err assign to Result<T,E>)
             if (!(decl_type->kind == TYPE_RESULT &&
                   (node->as.let_stmt.init->kind == NODE_OK_EXPR ||
@@ -538,7 +539,7 @@ static void check_stmt(Sema *ctx, AstNode *node) {
             }
         }
 
-        if (target_type && val_type && !ast_types_equal(target_type, val_type)) {
+        if (target_type && val_type && (!ast_types_equal(target_type, val_type)) && !ast_types_compatible(val_type, target_type)) {
             sema_error(ctx, &node->tok, "cannot assign '%s' to '%s'",
                        ast_type_str(val_type), ast_type_str(target_type));
         }


### PR DESCRIPTION
# Summary

Fixes an issue where empty arrays were strictly inferred as `[int]`, causing type mismatch errors when assigned to` [float]` variables. This PR also introduces Implicit Type Conversion support (e.g., `int` to `float`) to make the language more flexible, similar to **C**.

## The root cause (problem)

The issue wasn't in the `push` method, but in how the Semantic Analyzer (`sema.c`) handled empty array literals and strict type equality:

1. **Default Inference**: In `check_expr() #sema.c` for `NODE_ARRAY_LIT,` an empty array `[]` was hardcoded to `TYPE_INT` if no elements were present.
  ```c
  if (!elem_type) elem_type = ast_type_simple(TYPE_INT); // Defaulting to INT
  ```
2. **Strict Equality**: The compiler previously used `ast_types_equal()`, which is too rigid. It didn't understand that an `int` can safely be promoted to a `float`.

## The Solution

Instead of forcing a strict equality check, I've introduced a Type Compatibility layer:
* **New Utility**: Added `ast_types_compatible(from, to)` in `ast.c`. This function allows int to be assigned to float (Type Promotion).
* **Sema update**: Add `ast_types_compatible` to the assign check in both `NODE_LET_STMT` and `NODE_ASSIGN_STMT`
* **Flexible Arrays**: This change allows `let x: [float] = []` to pass because the inferred `[int]` is now considered compatible with the declared `[float]`

## Impact

* **Fixed**: `let bb: [float] = []`; no longer screams error like `error: cannot assign '[int]' of variable '[float]'`.
* **Feature**: Supports implicit casting from `in`t to `float` across assignments, matching C's behavior..

Closes #16 