### PR TITLE
fix: add urus_str_equal to compare urus string value

### DIFF
--- a/compiler/include/error.h
+++ b/compiler/include/error.h
@@ -1,5 +1,5 @@
-#ifndef SEMA_ERROR_H
-#define SEMA_ERROR_H
+#ifndef URUS_ERROR_H
+#define URUS_ERROR_H
 
 #include "token.h"
 

--- a/compiler/include/urus_runtime.h
+++ b/compiler/include/urus_runtime.h
@@ -12,7 +12,7 @@
 #include <ctype.h>
 
 // ============================================================
-// RAII (utility)
+// RAII
 // ============================================================
 
 #if defined(__clang__) || defined(__GNUC__)
@@ -46,6 +46,13 @@ static void urus_str_drop(urus_str **sp) {
         free(*sp);
         *sp = NULL;
     }
+}
+
+static inline bool urus_str_equal(urus_str *a, urus_str *b) {
+    if (a == b) return true; // compare address
+    if (a->data== b->data) return true; // compare address
+    if (a->len != b->len) return false;
+    return memcmp(a->data, b->data, a->len) == 0;
 }
 
 static urus_str *urus_str_from(const char *s) {

--- a/compiler/src/codegen.c
+++ b/compiler/src/codegen.c
@@ -208,6 +208,17 @@ static void gen_expr(CodeBuf *buf, AstNode *node) {
         emit(buf, "%s", node->as.ident.name);
         break;
     case NODE_BINARY:
+        if ((node->as.binary.op == TOK_EQ || node->as.binary.op == TOK_NEQ) &&
+                node->as.binary.left->resolved_type->kind == TYPE_STR) {
+            emit(buf, "(%surus_%s_equal(", node->as.binary.op == TOK_EQ ? "" : "!",
+                    ast_type_str(node->as.binary.left->resolved_type));
+            gen_expr(buf, node->as.binary.left);
+            emit(buf, ", ");
+            gen_expr(buf, node->as.binary.right);
+            emit(buf, "))");
+            break;
+        }
+
         if (node->as.binary.op == TOK_PLUS && expr_is_string(node)) {
             emit(buf, "urus_str_concat(");
             gen_expr(buf, node->as.binary.left);
@@ -767,7 +778,6 @@ static void gen_enum_decl(CodeBuf *buf, AstNode *node) {
 
     // Tagged union struct
     emit(buf, "typedef struct %s {\n", name);
-    emit(buf, "    int rc;\n");
     emit(buf, "    int tag;\n");
     emit(buf, "    union {\n");
     for (int i = 0; i < node->as.enum_decl.variant_count; i++) {


### PR DESCRIPTION
## Previously
If you compare two string like `if ("John" == "John")` that condition never reaches `true`. Why? it is because in c (the transpiled c code) you can't compare a `char *` with `char *`. so i made function `urus_str_equal` in `urus_runtime.h` and implement it in `TOK_EQ/NEQ` in the `NODE_BINARY` check in `codegen.c`

## Changes:
fix: add check for TOK_EQ/NEQ in NODE_BINARY
fix: change SEMA_ERROR_H to URUS_ERROR_H in error.h
chore: remove int rc from enum definition in codegen

Closes #34 