### PR TITLE
fix: default output name based on platform (a.out/linux, a.exe/windows)

### DIFF
--- a/compiler/src/main.c
+++ b/compiler/src/main.c
@@ -203,7 +203,7 @@ static void show_help(char *progname) {
         "  --tokens    Display Lexer tokens\n"
         "  --ast       Display the Abstract Syntax Tree (AST)\n"
         "  --emit-c    Print generated C code to stdout\n"
-        "  -o <file>   Specify output executable name (default: a.exe)\n\n"
+        "  -o <file>   Specify output executable name (default: a.out on Linux, a.exe on Windows)\n\n"
         "Example:\n"
         "  %s main.urus -o app \n", progname, progname
     );
@@ -330,7 +330,11 @@ int main(int argc, char **argv) {
         printf("%s", cbuf.data);
     } else {
         const char *c_path = "_urus_tmp.c";
+#ifdef _WIN32
         const char *out_path = output ? output : "a.exe";
+#else
+        const char *out_path = output ? output : "a.out";
+#endif
 
         FILE *f = fopen(c_path, "wb");
         if (!f) {


### PR DESCRIPTION
## Description

Fixes the default output executable name to be platform-appropriate: a.out on Linux/macOS and a.exe on Windows.

## Type of Change

<!-- Check the relevant option(s): -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing code to break)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## Changes Made

- Added #ifdef _WIN32 conditional in compiler/src/main.c to set default output name based on platform
- Updated help text to reflect both platforms

## Testing

- [x] Tested on Linux - compiled a sample .rus file, outputs a.out by default

## Checklist

- [x] My code follows the project's coding conventions
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix or feature works
- [ ] All new and existing tests pass
- [x] My changes generate no new compiler warnings
