### PR TITLE
fix: false-positive unused struct warning bug#53

### DIFF
--- a/compiler/src/sema.c
+++ b/compiler/src/sema.c
@@ -455,6 +455,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
                            name, node->as.struct_lit.fields[i].name);
             }
         }
+        st->is_referenced = true;
         return set_type(node, ast_type_named(name));
     }
 


### PR DESCRIPTION
this happen because in `NODE_STRUCT_LIT` we forget to set struct symbols `is_referenced` to `true`

Closes #53 