### PR TITLE
John/refractor/module

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -35,7 +35,9 @@ set(SOURCES
     src/parser.c
     src/util.c
     src/error.c
-    src/sema.c
+    src/Sema/sema.c
+    src/Sema/scope.c
+    src/Sema/builtins.c
     src/codegen.c
     src/preprocess.c
 )

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SOURCES
     src/error.c
     src/sema.c
     src/codegen.c
+    src/preprocess.c
 )
 
 add_executable(urusc ${SOURCES} ${URUS_RUNTIME_EMBEDDED})

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -5,24 +5,11 @@
 #include <stdbool.h>
 
 typedef struct {
-    char *c_name;
-    AstType *type;
-} CGSym;
-
-typedef struct CGScope {
-    CGSym syms[128]; // TODO: Use dynamic memory than static 128 (other reference: raii_register()@codegen.c)
-    int count;
-    bool is_loop;
-    struct CGScope *parent;
-} CGScope;
-
-typedef struct {
     char *data;
     size_t len;
     size_t cap;
     int indent;
     int tmp_counter;
-    CGScope *current_scope;
 } CodeBuf;
 
 void codegen_init(CodeBuf *buf);

--- a/compiler/include/preprocess.h
+++ b/compiler/include/preprocess.h
@@ -1,0 +1,16 @@
+#ifndef URUS_PREPROCESS_H
+#define URUS_PREPROCESS_H
+
+#include "ast.h"
+#include <stdbool.h>
+
+// --- Import resolution ---
+
+// Resolves and merges all import declarations in the program AST.
+bool preprocess_imports(AstNode *program, const char *base_file);
+
+// Still an Idea: reset state between file compilations (if you ever do multi-file
+// compilation in one process lifetime)
+// void preprocess_reset(void);
+
+#endif

--- a/compiler/include/sema.h
+++ b/compiler/include/sema.h
@@ -4,7 +4,43 @@
 #include "ast.h"
 #include <stdbool.h>
 
+typedef struct {
+    char *name;
+    AstType *type;
+    Token tok; // For error tracking
+    bool is_mut;
+    bool is_fn;
+    bool is_referenced;
+    bool is_builtin; // To avoid making warning on builtin function/variable
+    Param *params;
+    int param_count;
+    AstType *return_type;
+    bool is_struct;
+    Param *fields;
+    int field_count;
+    bool is_enum;
+    EnumVariant *variants;
+    int variant_count;
+} SemaSymbol;
+
+typedef struct Scope {
+    SemaSymbol *syms;
+    int count, cap;
+    struct Scope *parent;
+} SemaScope;
+
+typedef struct {
+    SemaScope *current;
+    AstType *current_fn_return;
+    const char *filename;
+    int errors;
+    int loop_depth;
+} SemaCtx;
+
 // Returns true if analysis succeeded (no errors)
 bool sema_analyze(AstNode *program, const char *filename);
+
+// Builtin registration (sema_builtins.c)
+void sema_register_builtins(SemaScope *global);
 
 #endif

--- a/compiler/src/Sema/builtins.c
+++ b/compiler/src/Sema/builtins.c
@@ -1,0 +1,77 @@
+#include "sema.h"
+#include "./scope.h"
+#include <stdlib.h>
+#include <stdarg.h>
+
+static void add_builtin(SemaScope *global, const char *name, AstType *ret,
+                        int nparams, ...) {
+    SemaSymbol *s = scope_add(global, name, (Token){0});
+    s->is_fn = true;
+    s->is_builtin = true;
+    s->param_count = nparams;
+    s->return_type = ret;
+    if (nparams > 0) {
+        s->params = calloc((size_t)nparams, sizeof(Param));
+        va_list args;
+        va_start(args, nparams);
+        for (int i = 0; i < nparams; i++) {
+            s->params[i].name = va_arg(args, char *);
+            s->params[i].type = va_arg(args, AstType *);
+        }
+        va_end(args);
+    }
+}
+
+#define T_INT   ast_type_simple(TYPE_INT)
+#define T_FLOAT ast_type_simple(TYPE_FLOAT)
+#define T_BOOL  ast_type_simple(TYPE_BOOL)
+#define T_STR   ast_type_simple(TYPE_STR)
+#define T_VOID  ast_type_simple(TYPE_VOID)
+#define T_ANY   NULL
+
+// Register builtin definition into sema scope
+// to prevent unnecessary errors
+void sema_register_builtins(SemaScope *global) {
+    add_builtin(global, "print",    T_VOID,  1, "value", T_ANY);
+    add_builtin(global, "to_str",   T_STR,   1, "value", T_ANY);
+    add_builtin(global, "to_int",   T_INT,   1, "value", T_ANY);
+    add_builtin(global, "to_float", T_FLOAT, 1, "value", T_ANY);
+    add_builtin(global, "len",      T_INT,   1, "arr",   T_ANY);
+    add_builtin(global, "push",     T_VOID,  2, "arr", T_ANY, "value", T_ANY);
+    add_builtin(global, "pop",      T_VOID,  1, "arr", T_ANY);
+
+    add_builtin(global, "str_len",        T_INT,  1, "s", T_STR);
+    add_builtin(global, "str_slice",      T_STR,  3, "s", T_STR, "start", T_INT, "end", T_INT);
+    add_builtin(global, "str_find",       T_INT,  2, "s", T_STR, "sub", T_STR);
+    add_builtin(global, "str_contains",   T_BOOL, 2, "s", T_STR, "sub", T_STR);
+    add_builtin(global, "str_upper",      T_STR,  1, "s", T_STR);
+    add_builtin(global, "str_lower",      T_STR,  1, "s", T_STR);
+    add_builtin(global, "str_trim",       T_STR,  1, "s", T_STR);
+    add_builtin(global, "str_replace",    T_STR,  3, "s", T_STR, "old", T_STR, "new", T_STR);
+    add_builtin(global, "str_starts_with",T_BOOL, 2, "s", T_STR, "prefix", T_STR);
+    add_builtin(global, "str_ends_with",  T_BOOL, 2, "s", T_STR, "suffix", T_STR);
+    add_builtin(global, "str_split",      ast_type_array(T_STR), 2, "s", T_STR, "delim", T_STR);
+    add_builtin(global, "char_at",        T_STR,  2, "s", T_STR, "i", T_INT);
+
+    add_builtin(global, "abs",  T_INT,   1, "x", T_INT);
+    add_builtin(global, "fabs", T_FLOAT, 1, "x", T_FLOAT);
+    add_builtin(global, "sqrt", T_FLOAT, 1, "x", T_FLOAT);
+    add_builtin(global, "pow",  T_FLOAT, 2, "x", T_FLOAT, "y", T_FLOAT);
+    add_builtin(global, "min",  T_INT,   2, "a", T_INT, "b", T_INT);
+    add_builtin(global, "max",  T_INT,   2, "a", T_INT, "b", T_INT);
+    add_builtin(global, "fmin", T_FLOAT, 2, "a", T_FLOAT, "b", T_FLOAT);
+    add_builtin(global, "fmax", T_FLOAT, 2, "a", T_FLOAT, "b", T_FLOAT);
+
+    add_builtin(global, "input",       T_STR,  0);
+    add_builtin(global, "read_file",   T_STR,  1, "path", T_STR);
+    add_builtin(global, "write_file",  T_VOID, 2, "path", T_STR, "content", T_STR);
+    add_builtin(global, "append_file", T_VOID, 2, "path", T_STR, "content", T_STR);
+
+    add_builtin(global, "exit",   T_VOID, 1, "code", T_INT);
+    add_builtin(global, "assert", T_VOID, 2, "cond", T_BOOL, "msg", T_STR);
+
+    add_builtin(global, "is_ok",  T_BOOL, 1, "r", T_ANY);
+    add_builtin(global, "is_err", T_BOOL, 1, "r", T_ANY);
+    add_builtin(global, "unwrap", T_ANY,  1, "r", T_ANY);
+    add_builtin(global, "unwrap_err", T_ANY, 1, "r", T_ANY);
+}

--- a/compiler/src/Sema/scope.c
+++ b/compiler/src/Sema/scope.c
@@ -1,0 +1,43 @@
+#include "scope.h"
+#include <stdlib.h>
+#include <string.h>
+
+SemaScope *scope_new(SemaScope *parent) {
+    SemaScope *s = calloc(1, sizeof(SemaScope));
+    s->parent = parent;
+    s->cap = 8;
+    s->syms = malloc(sizeof(SemaSymbol) * (size_t)s->cap);
+    return s;
+}
+
+void scope_free(SemaScope *s) {
+    free(s->syms);
+    free(s);
+}
+
+SemaSymbol *scope_lookup_local(SemaScope *s, const char *name) {
+    for (int i = 0; i < s->count; i++) {
+        if (strcmp(s->syms[i].name, name) == 0) return &s->syms[i];
+    }
+    return NULL;
+}
+
+SemaSymbol *scope_lookup(SemaScope *s, const char *name) {
+    for (SemaScope *cur = s; cur; cur = cur->parent) {
+        SemaSymbol *sym = scope_lookup_local(cur, name);
+        if (sym) return sym;
+    }
+    return NULL;
+}
+
+SemaSymbol *scope_add(SemaScope *s, const char *name, Token tok) {
+    if (s->count >= s->cap) {
+        s->cap *= 2;
+        s->syms = realloc(s->syms, sizeof(SemaSymbol) * (size_t)s->cap);
+    }
+    SemaSymbol *sym = &s->syms[s->count++];
+    memset(sym, 0, sizeof(SemaSymbol));
+    sym->name = (char *)name;
+    sym->tok = tok;
+    return sym;
+}

--- a/compiler/src/Sema/scope.h
+++ b/compiler/src/Sema/scope.h
@@ -1,0 +1,14 @@
+#ifndef URUS_SEMA_SCOPE_H
+#define URUS_SEMA_SCOPE_H
+
+#include "sema.h"
+
+// TODO: Add simple documentation about function here
+
+SemaScope *scope_new(SemaScope *parent);
+void scope_free(SemaScope *s);
+SemaSymbol *scope_lookup_local(SemaScope *s, const char *name);
+SemaSymbol *scope_lookup(SemaScope *s, const char *name);
+SemaSymbol *scope_add(SemaScope *s, const char *name, Token tok);
+
+#endif

--- a/compiler/src/Sema/sema.c
+++ b/compiler/src/Sema/sema.c
@@ -3,94 +3,16 @@
 #endif
 
 #include "sema.h"
+#include "./scope.h"
 #include "error.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
 
-// ============================================================
-// Symbol & Scope
-// ============================================================
-
-typedef struct {
-    char *name;
-    AstType *type;
-    Token tok; // For error tracking
-    bool is_mut;
-    bool is_fn;
-    bool is_referenced;
-    bool is_builtin; // To avoid making warning on builtin function/variable
-    Param *params;
-    int param_count;
-    AstType *return_type;
-    bool is_struct;
-    Param *fields;
-    int field_count;
-    bool is_enum;
-    EnumVariant *variants;
-    int variant_count;
-} Symbol;
-
-typedef struct Scope {
-    Symbol *syms;
-    int count, cap;
-    struct Scope *parent;
-} Scope;
-
-typedef struct {
-    Scope *current;
-    AstType *current_fn_return;
-    const char *filename;
-    int errors;
-    int loop_depth;
-} Sema;
-
-// ---- Scope management ----
-
-static Scope *scope_new(Scope *parent) {
-    Scope *s = calloc(1, sizeof(Scope));
-    s->parent = parent;
-    s->cap = 8;
-    s->syms = malloc(sizeof(Symbol) * (size_t)s->cap);
-    return s;
-}
-
-static void scope_free(Scope *s) {
-    free(s->syms);
-    free(s);
-}
-
-static Symbol *scope_lookup_local(Scope *s, const char *name) {
-    for (int i = 0; i < s->count; i++) {
-        if (strcmp(s->syms[i].name, name) == 0) return &s->syms[i];
-    }
-    return NULL;
-}
-
-static Symbol *scope_lookup(Scope *s, const char *name) {
-    for (Scope *cur = s; cur; cur = cur->parent) {
-        Symbol *sym = scope_lookup_local(cur, name);
-        if (sym) return sym;
-    }
-    return NULL;
-}
-
-static Symbol *scope_add(Scope *s, const char *name, Token tok) {
-    if (s->count >= s->cap) {
-        s->cap *= 2;
-        s->syms = realloc(s->syms, sizeof(Symbol) * (size_t)s->cap);
-    }
-    Symbol *sym = &s->syms[s->count++];
-    memset(sym, 0, sizeof(Symbol));
-    sym->name = (char *)name;
-    sym->tok = tok;
-    return sym;
-}
-
 // ---- Reporting system ----
 
-static void sema_error(Sema *ctx, Token *t, const char *fmt, ...) {
+static void sema_error(SemaCtx *ctx, Token *t, const char *fmt, ...) {
     char msg[1024];
 
     va_list args;
@@ -102,7 +24,7 @@ static void sema_error(Sema *ctx, Token *t, const char *fmt, ...) {
     ctx->errors++;
 }
 
-static void sema_warn(Sema *ctx, Token *t, const char *fmt, ...) {
+static void sema_warn(SemaCtx *ctx, Token *t, const char *fmt, ...) {
     char msg[1024];
 
     va_list args;
@@ -114,9 +36,9 @@ static void sema_warn(Sema *ctx, Token *t, const char *fmt, ...) {
 }
 
 // ---- Forward declarations ----
-static AstType *check_expr(Sema *ctx, AstNode *node);
-static void check_stmt(Sema *ctx, AstNode *node);
-static void check_block(Sema *ctx, AstNode *node);
+static AstType *check_expr(SemaCtx *ctx, AstNode *node);
+static void check_stmt(SemaCtx *ctx, AstNode *node);
+static void check_block(SemaCtx *ctx, AstNode *node);
 
 // ---- Expression type checking ----
 
@@ -125,7 +47,7 @@ static AstType *set_type(AstNode *node, AstType *t) {
     return t;
 }
 
-static AstType *check_expr(Sema *ctx, AstNode *node) {
+static AstType *check_expr(SemaCtx *ctx, AstNode *node) {
     if (!node) return NULL;
 
     // Warn about unnecessary parentheses: ((expr)), (literal), (ident)
@@ -151,7 +73,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
         return set_type(node, ast_type_simple(TYPE_BOOL));
 
     case NODE_IDENT: {
-        Symbol *sym = scope_lookup(ctx->current, node->as.ident.name);
+        SemaSymbol *sym = scope_lookup(ctx->current, node->as.ident.name);
         if (!sym || (sym->is_fn || sym->is_enum || sym->is_struct)) {
             sema_error(ctx, &node->tok, "undefined variable '%s'", node->as.ident.name);
             return set_type(node, ast_type_simple(TYPE_VOID));
@@ -238,7 +160,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
                 // Look for StructName_method
                 char fn_name_buf[256];
                 snprintf(fn_name_buf, sizeof(fn_name_buf), "%s_%s", obj_type->name, method);
-                Symbol *method_sym = scope_lookup(ctx->current, fn_name_buf);
+                SemaSymbol *method_sym = scope_lookup(ctx->current, fn_name_buf);
 
                 if (method_sym && method_sym->is_fn) {
                     // Rewrite: change callee to ident, prepend obj as first arg
@@ -278,7 +200,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
         }
 
         const char *fn_name = node->as.call.callee->as.ident.name;
-        Symbol *sym = scope_lookup(ctx->current, fn_name);
+        SemaSymbol *sym = scope_lookup(ctx->current, fn_name);
         if (!sym) {
             sema_error(ctx, &node->as.call.callee->tok, "undefined function '%s'", fn_name);
             for (int i = 0; i < node->as.call.arg_count; i++)
@@ -381,7 +303,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
                        ast_type_str(obj_type));
             return set_type(node, ast_type_simple(TYPE_VOID));
         }
-        Symbol *st = scope_lookup(ctx->current, obj_type->name);
+        SemaSymbol *st = scope_lookup(ctx->current, obj_type->name);
         if (!st || !st->is_struct) {
             if (!st->is_struct) {
                 sema_error(ctx, &node->tok, "'%s' is not struct", obj_type->name);
@@ -432,7 +354,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
 
     case NODE_STRUCT_LIT: {
         const char *name = node->as.struct_lit.name;
-        Symbol *st = scope_lookup(ctx->current, name);
+        SemaSymbol *st = scope_lookup(ctx->current, name);
         if (!st || !st->is_struct) {
             sema_error(ctx, &node->tok, "unknown struct '%s'", name);
             for (int i = 0; i < node->as.struct_lit.field_count; i++)
@@ -485,7 +407,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
 
     case NODE_ENUM_INIT: {
         const char *ename = node->as.enum_init.enum_name;
-        Symbol *sym = scope_lookup(ctx->current, ename);
+        SemaSymbol *sym = scope_lookup(ctx->current, ename);
         if (!sym || !sym->is_enum) {
             if (!sym->is_enum) {
                 sema_error(ctx, &node->tok, "'%s' is not enum", ename);
@@ -557,7 +479,7 @@ static AstType *check_expr(Sema *ctx, AstNode *node) {
 
 // ---- Statement checking ----
 
-static void check_stmt(Sema *ctx, AstNode *node) {
+static void check_stmt(SemaCtx *ctx, AstNode *node) {
     if (!node) return;
 
     switch (node->kind) {
@@ -580,7 +502,7 @@ static void check_stmt(Sema *ctx, AstNode *node) {
                        node->as.let_stmt.name);
         }
 
-        Symbol *sym = scope_add(ctx->current, node->as.let_stmt.name, node->tok);
+        SemaSymbol *sym = scope_add(ctx->current, node->as.let_stmt.name, node->tok);
         sym->type = decl_type;
         sym->is_mut = node->as.let_stmt.is_mut;
         break;
@@ -591,7 +513,7 @@ static void check_stmt(Sema *ctx, AstNode *node) {
         AstType *val_type = check_expr(ctx, node->as.assign_stmt.value);
 
         if (node->as.assign_stmt.target->kind == NODE_IDENT) {
-            Symbol *sym = scope_lookup(ctx->current, node->as.assign_stmt.target->as.ident.name);
+            SemaSymbol *sym = scope_lookup(ctx->current, node->as.assign_stmt.target->as.ident.name);
             if (sym && !sym->is_mut && !sym->is_fn) {
                 sema_error(ctx, &node->as.assign_stmt.value->tok, "cannot assign to immutable variable '%s'",
                            node->as.assign_stmt.target->as.ident.name);
@@ -644,9 +566,9 @@ static void check_stmt(Sema *ctx, AstNode *node) {
                                  ? ast_type_clone(iter_type->element)
                                  : ast_type_simple(TYPE_INT);
 
-            Scope *body_scope = scope_new(ctx->current);
+            SemaScope *body_scope = scope_new(ctx->current);
             ctx->current = body_scope;
-            Symbol *loop_var = scope_add(body_scope, node->as.for_stmt.var_name, node->tok);
+            SemaSymbol *loop_var = scope_add(body_scope, node->as.for_stmt.var_name, node->tok);
             loop_var->type = elem_type;
             loop_var->is_mut = false;
 
@@ -670,9 +592,9 @@ static void check_stmt(Sema *ctx, AstNode *node) {
                 sema_error(ctx, &node->as.for_stmt.end->tok, "for range end must be int, got '%s'", ast_type_str(end));
             }
 
-            Scope *body_scope = scope_new(ctx->current);
+            SemaScope *body_scope = scope_new(ctx->current);
             ctx->current = body_scope;
-            Symbol *loop_var = scope_add(body_scope, node->as.for_stmt.var_name, node->tok);
+            SemaSymbol *loop_var = scope_add(body_scope, node->as.for_stmt.var_name, node->tok);
             loop_var->type = ast_type_simple(TYPE_INT);
             loop_var->is_mut = false;
 
@@ -738,7 +660,7 @@ static void check_stmt(Sema *ctx, AstNode *node) {
                        ast_type_str(target_type));
             break;
         }
-        Symbol *enum_sym = scope_lookup(ctx->current, target_type->name);
+        SemaSymbol *enum_sym = scope_lookup(ctx->current, target_type->name);
         if (!enum_sym || !enum_sym->is_enum) {
             sema_error(ctx, &node->as.match_stmt.target->tok, "match target type '%s' is not an enum", target_type->name);
             break;
@@ -773,10 +695,10 @@ static void check_stmt(Sema *ctx, AstNode *node) {
             }
 
             // Check arm body with bindings in scope
-            Scope *arm_scope = scope_new(ctx->current);
+            SemaScope *arm_scope = scope_new(ctx->current);
             ctx->current = arm_scope;
             for (int b = 0; b < arm->binding_count && b < variant->field_count; b++) {
-                Symbol *binding = scope_add(arm_scope, arm->bindings[b], node->tok);
+                SemaSymbol *binding = scope_add(arm_scope, arm->bindings[b], node->tok);
                 binding->type = ast_type_clone(variant->fields[b].type);
                 binding->is_mut = false;
             }
@@ -795,9 +717,9 @@ static void check_stmt(Sema *ctx, AstNode *node) {
     }
 }
 
-static void check_unused_symbols(Sema *ctx, Scope *s) {
+static void check_unused_symbols(SemaCtx *ctx, SemaScope *s) {
     for (int i = 0; i < s->count; i++) {
-        Symbol *sym = &s->syms[i];
+        SemaSymbol *sym = &s->syms[i];
         if (sym->name[0] != '_' && strcmp(sym->name, "main") != 0 && !sym->is_builtin &&
                 !sym->is_referenced) {
             char *type = "variable";
@@ -811,8 +733,8 @@ static void check_unused_symbols(Sema *ctx, Scope *s) {
     }
 }
 
-static void check_block(Sema *ctx, AstNode *node) {
-    Scope *block_scope = scope_new(ctx->current);
+static void check_block(SemaCtx *ctx, AstNode *node) {
+    SemaScope *block_scope = scope_new(ctx->current);
     ctx->current = block_scope;
     for (int i = 0; i < node->as.block.stmt_count; i++) {
         check_stmt(ctx, node->as.block.stmts[i]);
@@ -822,88 +744,15 @@ static void check_block(Sema *ctx, AstNode *node) {
     scope_free(block_scope);
 }
 
-// ---- Builtins ----
-
-static void add_builtin(Scope *global, const char *name, AstType *ret,
-                        int nparams, ...) {
-    Symbol *s = scope_add(global, name, (Token){0});
-    s->is_fn = true;
-    s->is_builtin = true;
-    s->param_count = nparams;
-    s->return_type = ret;
-    if (nparams > 0) {
-        s->params = calloc((size_t)nparams, sizeof(Param));
-        va_list args;
-        va_start(args, nparams);
-        for (int i = 0; i < nparams; i++) {
-            s->params[i].name = va_arg(args, char *);
-            s->params[i].type = va_arg(args, AstType *);
-        }
-        va_end(args);
-    }
-}
-
-#define T_INT   ast_type_simple(TYPE_INT)
-#define T_FLOAT ast_type_simple(TYPE_FLOAT)
-#define T_BOOL  ast_type_simple(TYPE_BOOL)
-#define T_STR   ast_type_simple(TYPE_STR)
-#define T_VOID  ast_type_simple(TYPE_VOID)
-#define T_ANY   NULL
-
-static void register_builtins(Scope *global) {
-    add_builtin(global, "print",    T_VOID,  1, "value", T_ANY);
-    add_builtin(global, "to_str",   T_STR,   1, "value", T_ANY);
-    add_builtin(global, "to_int",   T_INT,   1, "value", T_ANY);
-    add_builtin(global, "to_float", T_FLOAT, 1, "value", T_ANY);
-    add_builtin(global, "len",      T_INT,   1, "arr",   T_ANY);
-    add_builtin(global, "push",     T_VOID,  2, "arr", T_ANY, "value", T_ANY);
-    add_builtin(global, "pop",      T_VOID,  1, "arr", T_ANY);
-
-    add_builtin(global, "str_len",        T_INT,  1, "s", T_STR);
-    add_builtin(global, "str_slice",      T_STR,  3, "s", T_STR, "start", T_INT, "end", T_INT);
-    add_builtin(global, "str_find",       T_INT,  2, "s", T_STR, "sub", T_STR);
-    add_builtin(global, "str_contains",   T_BOOL, 2, "s", T_STR, "sub", T_STR);
-    add_builtin(global, "str_upper",      T_STR,  1, "s", T_STR);
-    add_builtin(global, "str_lower",      T_STR,  1, "s", T_STR);
-    add_builtin(global, "str_trim",       T_STR,  1, "s", T_STR);
-    add_builtin(global, "str_replace",    T_STR,  3, "s", T_STR, "old", T_STR, "new", T_STR);
-    add_builtin(global, "str_starts_with",T_BOOL, 2, "s", T_STR, "prefix", T_STR);
-    add_builtin(global, "str_ends_with",  T_BOOL, 2, "s", T_STR, "suffix", T_STR);
-    add_builtin(global, "str_split",      ast_type_array(T_STR), 2, "s", T_STR, "delim", T_STR);
-    add_builtin(global, "char_at",        T_STR,  2, "s", T_STR, "i", T_INT);
-
-    add_builtin(global, "abs",  T_INT,   1, "x", T_INT);
-    add_builtin(global, "fabs", T_FLOAT, 1, "x", T_FLOAT);
-    add_builtin(global, "sqrt", T_FLOAT, 1, "x", T_FLOAT);
-    add_builtin(global, "pow",  T_FLOAT, 2, "x", T_FLOAT, "y", T_FLOAT);
-    add_builtin(global, "min",  T_INT,   2, "a", T_INT, "b", T_INT);
-    add_builtin(global, "max",  T_INT,   2, "a", T_INT, "b", T_INT);
-    add_builtin(global, "fmin", T_FLOAT, 2, "a", T_FLOAT, "b", T_FLOAT);
-    add_builtin(global, "fmax", T_FLOAT, 2, "a", T_FLOAT, "b", T_FLOAT);
-
-    add_builtin(global, "input",       T_STR,  0);
-    add_builtin(global, "read_file",   T_STR,  1, "path", T_STR);
-    add_builtin(global, "write_file",  T_VOID, 2, "path", T_STR, "content", T_STR);
-    add_builtin(global, "append_file", T_VOID, 2, "path", T_STR, "content", T_STR);
-
-    add_builtin(global, "exit",   T_VOID, 1, "code", T_INT);
-    add_builtin(global, "assert", T_VOID, 2, "cond", T_BOOL, "msg", T_STR);
-
-    add_builtin(global, "is_ok",  T_BOOL, 1, "r", T_ANY);
-    add_builtin(global, "is_err", T_BOOL, 1, "r", T_ANY);
-    add_builtin(global, "unwrap", T_ANY,  1, "r", T_ANY);
-    add_builtin(global, "unwrap_err", T_ANY, 1, "r", T_ANY);
-}
-
 // ---- Top-level ----
 
 bool sema_analyze(AstNode *program, const char *filename) {
-    Sema ctx = {0};
-    Scope *global = scope_new(NULL);
+    SemaCtx ctx = {0};
+    SemaScope *global = scope_new(NULL);
     ctx.filename = filename;
     ctx.current = global;
 
-    register_builtins(global);
+    sema_register_builtins(global);
 
     // Pass 1: register all structs, enums, and function signatures
     for (int i = 0; i < program->as.program.decl_count; i++) {
@@ -913,7 +762,7 @@ bool sema_analyze(AstNode *program, const char *filename) {
                 sema_error(&ctx, &d->tok, "duplicate struct '%s'", d->as.struct_decl.name);
                 continue;
             }
-            Symbol *s = scope_add(global, d->as.struct_decl.name, d->tok);
+            SemaSymbol *s = scope_add(global, d->as.struct_decl.name, d->tok);
             s->is_struct = true;
             s->fields = d->as.struct_decl.fields;
             s->field_count = d->as.struct_decl.field_count;
@@ -923,7 +772,7 @@ bool sema_analyze(AstNode *program, const char *filename) {
                 sema_error(&ctx, &d->tok, "duplicate enum '%s'", d->as.enum_decl.name);
                 continue;
             }
-            Symbol *s = scope_add(global, d->as.enum_decl.name, d->tok);
+            SemaSymbol *s = scope_add(global, d->as.enum_decl.name, d->tok);
             s->is_enum = true;
             s->variants = d->as.enum_decl.variants;
             s->variant_count = d->as.enum_decl.variant_count;
@@ -939,7 +788,7 @@ bool sema_analyze(AstNode *program, const char *filename) {
                            d->as.fn_decl.return_type->name);
                 continue;
             }
-            Symbol *s = scope_add(global, d->as.fn_decl.name, d->tok);
+            SemaSymbol *s = scope_add(global, d->as.fn_decl.name, d->tok);
             s->is_fn = true;
             s->params = d->as.fn_decl.params;
             s->param_count = d->as.fn_decl.param_count;
@@ -951,13 +800,13 @@ bool sema_analyze(AstNode *program, const char *filename) {
     for (int i = 0; i < program->as.program.decl_count; i++) {
         AstNode *d = program->as.program.decls[i];
         if (d->kind == NODE_FN_DECL) {
-            Scope *fn_scope = scope_new(global);
+            SemaScope *fn_scope = scope_new(global);
             ctx.current = fn_scope;
             ctx.current_fn_return = d->as.fn_decl.return_type;
 
             for (int j = 0; j < d->as.fn_decl.param_count; j++) {
                 Param *p_decl = &d->as.fn_decl.params[j];
-                Symbol *p = scope_add(fn_scope, d->as.fn_decl.params[j].name, d->tok);
+                SemaSymbol *p = scope_add(fn_scope, d->as.fn_decl.params[j].name, d->tok);
                 p->type = d->as.fn_decl.params[j].type;
                 p->is_mut = false;
 

--- a/compiler/src/codegen.c
+++ b/compiler/src/codegen.c
@@ -184,7 +184,6 @@ void codegen_init(CodeBuf *buf) {
     buf->data[0] = '\0';
     buf->indent = 0;
     buf->tmp_counter = 0;
-    buf->current_scope = NULL;
 }
 
 void codegen_free(CodeBuf *buf) {

--- a/compiler/src/main.c
+++ b/compiler/src/main.c
@@ -26,6 +26,7 @@
 #include "ast.h"
 #include "codegen.h"
 #include "sema.h"
+#include "preprocess.h"
 
 // Find gcc executable, trying common paths on Windows
 static const char *find_gcc(void) {
@@ -46,138 +47,6 @@ static const char *find_gcc(void) {
 #else
     return "gcc";
 #endif
-}
-
-// ---- Import resolution ----
-
-// Track imported files to detect circular imports
-#define MAX_IMPORTS 64
-static const char *imported_files[MAX_IMPORTS];
-static int import_count = 0;
-
-static bool already_imported(const char *path) {
-    for (int i = 0; i < import_count; i++) {
-        if (strcmp(imported_files[i], path) == 0) return true;
-    }
-    return false;
-}
-
-// Resolve a relative import path based on the base file directory
-static char *resolve_import_path(const char *base_file, const char *import_path) {
-    // Find last / or backslash in base_file
-    const char *last_sep = NULL;
-    for (const char *p = base_file; *p; p++) {
-        if (*p == '/' || *p == '\\') last_sep = p;
-    }
-
-    if (!last_sep) {
-        return strdup(import_path);
-    }
-
-    size_t dir_len = (size_t)(last_sep - base_file + 1);
-    size_t imp_len = strlen(import_path);
-    char *full = malloc(dir_len + imp_len + 1);
-    memcpy(full, base_file, dir_len);
-    memcpy(full + dir_len, import_path, imp_len);
-    full[dir_len + imp_len] = '\0';
-    return full;
-}
-
-// Process imports: lex+parse imported files and merge declarations into program
-static bool process_imports(AstNode *program, const char *base_file) {
-    for (int i = 0; i < program->as.program.decl_count; i++) {
-        AstNode *d = program->as.program.decls[i];
-        if (d->kind != NODE_IMPORT) continue;
-
-        char *path = resolve_import_path(base_file, d->as.import_decl.path);
-
-        if (already_imported(path)) {
-            free(path);
-            continue;
-        }
-
-        if (import_count >= MAX_IMPORTS) {
-            fprintf(stderr, "Error: too many imports (max %d)\n", MAX_IMPORTS);
-            free(path);
-            return false;
-        }
-        imported_files[import_count++] = path;
-
-        size_t len;
-        char *source = read_file(path, &len);
-        if (!source) {
-            fprintf(stderr, "Error: cannot import '%s'\n", d->as.import_decl.path);
-            return false;
-        }
-
-        Lexer lexer;
-        lexer_init(&lexer, source, len);
-        int token_count;
-        Token *tokens = lexer_tokenize(&lexer, &token_count);
-        if (!tokens) {
-            free(source);
-            return false;
-        }
-
-        Parser parser;
-        parser.filename = path;
-        parser_init(&parser, tokens, token_count);
-        AstNode *imported = parser_parse(&parser);
-
-        if (parser.had_error) {
-            fprintf(stderr, "Error parsing imported file '%s'\n", path);
-            ast_free(imported);
-            free(tokens);
-            free(source);
-            return false;
-        }
-
-        // Recursively process imports in the imported file
-        if (!process_imports(imported, path)) {
-            ast_free(imported);
-            free(tokens);
-            free(source);
-            return false;
-        }
-
-        // Merge imported declarations into program (insert before current position)
-        int new_count = program->as.program.decl_count + imported->as.program.decl_count - 1;
-        AstNode **new_decls = malloc(sizeof(AstNode *) * (size_t)(new_count + 1));
-
-        int pos = 0;
-        // Copy declarations before the import statement
-        for (int j = 0; j < i; j++) {
-            new_decls[pos++] = program->as.program.decls[j];
-        }
-        // Insert imported declarations (skip imports from imported file)
-        for (int j = 0; j < imported->as.program.decl_count; j++) {
-            if (imported->as.program.decls[j]->kind != NODE_IMPORT) {
-                new_decls[pos++] = imported->as.program.decls[j];
-                imported->as.program.decls[j] = NULL; // transfer ownership
-            }
-        }
-        // Skip the import statement itself
-        // Copy declarations after the import
-        for (int j = i + 1; j < program->as.program.decl_count; j++) {
-            new_decls[pos++] = program->as.program.decls[j];
-        }
-
-        free(program->as.program.decls);
-        program->as.program.decls = new_decls;
-        program->as.program.decl_count = pos;
-
-        // Don't free imported->decls since we transferred ownership
-        free(imported->as.program.decls);
-        imported->as.program.decls = NULL;
-        imported->as.program.decl_count = 0;
-        ast_free(imported);
-        free(tokens);
-        // Note: source memory is borrowed by tokens, don't free yet
-
-        // Re-scan from beginning since we modified the array
-        i = -1;
-    }
-    return true;
 }
 
 // ---- Main ----
@@ -286,9 +155,6 @@ int main(int argc, char **argv) {
     char *source = read_file(path, &len);
     if (!source) return 1;
 
-    // Mark base file as imported (to prevent circular self-import)
-    imported_files[import_count++] = path;
-
     // Lexing
     Lexer lexer;
     lexer_init(&lexer, source, len);
@@ -318,7 +184,7 @@ int main(int argc, char **argv) {
     }
 
     // Process imports
-    if (!process_imports(program, path)) {
+    if (!preprocess_imports(program, path)) {
         fprintf(stderr, "Import resolution failed.\n");
         ast_free(program);
         free(tokens);

--- a/compiler/src/preprocess.c
+++ b/compiler/src/preprocess.c
@@ -1,0 +1,140 @@
+#include "preprocess.h"
+#include "lexer.h"
+#include "parser.h"
+#include "util.h"
+#include "ast.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// --- Import resolution ---
+
+// Track imported files to detect circular imports
+#define MAX_IMPORTS 64
+static const char *imported_files[MAX_IMPORTS];
+static int import_count = 0;
+
+static bool already_imported(const char *path) {
+    for (int i = 0; i < import_count; i++) {
+        if (strcmp(path, imported_files[i]) == 0) return true;
+    }
+    return false;
+}
+static char *resolve_import_path(const char *base_file, const char *import_path) {
+    // Find last / or backslash in base_file
+    const char *last_sep = NULL;
+    for (const char *p = base_file; *p; p++) {
+        if (*p == '/' || *p == '\\') last_sep = p;
+    }
+
+    if (!last_sep) {
+        return strdup(import_path);
+    }
+
+    size_t dir_len = (size_t)(last_sep - base_file + 1);
+    size_t imp_len = strlen(import_path);
+    char *full = malloc(dir_len + imp_len + 1);
+    memcpy(full, base_file, dir_len);
+    memcpy(full + dir_len, import_path, imp_len);
+    full[dir_len + imp_len] = '\0';
+    return full;
+}
+
+bool preprocess_imports(AstNode *program, const char *base_file) {
+    // Mark base file as imported (to prevent circular self-import)
+    imported_files[import_count++] = base_file;
+
+    for (int i = 0; i < program->as.program.decl_count; i++) {
+        AstNode *d = program->as.program.decls[i];
+        if (d->kind != NODE_IMPORT) continue;
+
+        char *path = resolve_import_path(base_file, d->as.import_decl.path);
+
+        if (already_imported(path)) {
+            free(path);
+            continue;
+        }
+
+        if (import_count >= MAX_IMPORTS) {
+            fprintf(stderr, "Error: too many imports (max %d)\n", MAX_IMPORTS);
+            free(path);
+            return false;
+        }
+        imported_files[import_count++] = path;
+
+        size_t len;
+        char *source = read_file(path, &len);
+        if (!source) {
+            fprintf(stderr, "Error: cannot import '%s'\n", d->as.import_decl.path);
+            return false;
+        }
+
+        Lexer lexer;
+        lexer_init(&lexer, source, len);
+        int token_count;
+        Token *tokens = lexer_tokenize(&lexer, &token_count);
+        if (!tokens) {
+            free(source);
+            return false;
+        }
+
+        Parser parser;
+        parser.filename = path;
+        parser_init(&parser, tokens, token_count);
+        AstNode *imported = parser_parse(&parser);
+
+        if (parser.had_error) {
+            fprintf(stderr, "Error parsing imported file '%s'\n", path);
+            ast_free(imported);
+            free(tokens);
+            free(source);
+            return false;
+        }
+
+        // Recursively process imports in the imported file
+        if (!preprocess_imports(imported, path)) {
+            ast_free(imported);
+            free(tokens);
+            free(source);
+            return false;
+        }
+
+        // Merge imported declarations into program (insert before current position)
+        int new_count = program->as.program.decl_count + imported->as.program.decl_count - 1;
+        AstNode **new_decls = malloc(sizeof(AstNode *) * (size_t)(new_count + 1));
+
+        int pos = 0;
+        // Copy declarations before the import statement
+        for (int j = 0; j < i; j++) {
+            new_decls[pos++] = program->as.program.decls[j];
+        }
+        // Insert imported declarations (skip imports from imported file)
+        for (int j = 0; j < imported->as.program.decl_count; j++) {
+            if (imported->as.program.decls[j]->kind != NODE_IMPORT) {
+                new_decls[pos++] = imported->as.program.decls[j];
+                imported->as.program.decls[j] = NULL; // transfer ownership
+            }
+        }
+        // Skip the import statement itself
+        // Copy declarations after the import
+        for (int j = i + 1; j < program->as.program.decl_count; j++) {
+            new_decls[pos++] = program->as.program.decls[j];
+        }
+
+        free(program->as.program.decls);
+        program->as.program.decls = new_decls;
+        program->as.program.decl_count = pos;
+
+        // Don't free imported->decls since we transferred ownership
+        free(imported->as.program.decls);
+        imported->as.program.decls = NULL;
+        imported->as.program.decl_count = 0;
+        ast_free(imported);
+        free(tokens);
+        // Note: source memory is borrowed by tokens, don't free yet
+
+        // Re-scan from beginning since we modified the array
+        i = -1;
+    }
+    return true;
+}


### PR DESCRIPTION
### Refactor for better separation of concerns and dead code removal.

Changes:
- remove dead `CGSym`/`CGScope` struct in `codegen`
- move semantic `add_builtin` into `builtins.c`
- move `Scope`, `Symbol`, `Sema` to `sema.h`
- add `Sema` prefix in `Scope`, `Symbol` typedef
- move semantic scope management to `scope.c`
- move semantic analysis to `Sema/`
- move import resolution to `preprocess.c`