### PR TITLE
feat: type inference for let statements

### DIFF
--- a/compiler/src/Sema/sema.c
+++ b/compiler/src/Sema/sema.c
@@ -514,6 +514,15 @@ static void check_stmt(SemaCtx *ctx, AstNode *node) {
             break;
         }
 
+        // Type inference: if no type annotation, use init type
+        if (!decl_type && init_type) {
+            decl_type = ast_type_clone(init_type);
+            node->as.let_stmt.type = decl_type;
+        } else if (!decl_type && !init_type) {
+            sema_error(ctx, &node->tok, "cannot infer type for variable '%s'",
+                       node->as.let_stmt.name);
+        }
+
         if (init_type && decl_type && (!ast_types_equal(init_type, decl_type) && !ast_types_compatible(init_type, decl_type))) {
             // Allow Result type coercion (Ok/Err assign to Result<T,E>)
             if (!(decl_type->kind == TYPE_RESULT &&

--- a/compiler/src/parser.c
+++ b/compiler/src/parser.c
@@ -827,8 +827,10 @@ static AstNode *parse_let(Parser *p) {
     }
 
     Token name = expect(p, TOK_IDENT, "expected variable name");
-    expect(p, TOK_COLON, "expected ':' after variable name");
-    AstType *type = parse_type(p);
+    AstType *type = NULL;
+    if (match(p, TOK_COLON)) {
+        type = parse_type(p);
+    }
     expect(p, TOK_ASSIGN, "expected '=' in let statement");
     AstNode *init = parse_expr(p);
     expect(p, TOK_SEMICOLON, "expected ';' after let statement");


### PR DESCRIPTION
## Summary
- Make type annotation optional in `let` statements
- Compiler infers type from initializer expression when `: type` is omitted
- `let x = 42;` inferred as `int`, `let s = "hello";` as `str`, etc.

Closes #78

## Test plan
- [x] All 23 existing tests pass
- [x] Verified inferred types for int, str, float, bool
- [x] Explicit type annotations still work as before