### PR TITLE
feat: add built-in HTTP request functions

### DIFF
--- a/compiler/include/urus_runtime.h
+++ b/compiler/include/urus_runtime.h
@@ -532,4 +532,69 @@ static void urus_assert(bool cond, urus_str *msg) {
     }
 }
 
+// ============================================================
+// HTTP (via libcurl or system command)
+// ============================================================
+
+#ifdef _WIN32
+#include <windows.h>
+#include <winhttp.h>
+#pragma comment(lib, "winhttp.lib")
+#else
+// On Unix, we use popen with curl
+#endif
+
+static urus_str *urus_http_get(urus_str *url) {
+    // Use popen + curl as portable fallback
+    char cmd[4096];
+    snprintf(cmd, sizeof(cmd), "curl -s \"%s\"", url->data);
+    FILE *fp = popen(cmd, "r");
+    if (!fp) {
+        fprintf(stderr, "Error: failed to execute curl\n");
+        return urus_str_from("");
+    }
+    size_t cap = 4096;
+    size_t len = 0;
+    char *buf = (char *)urus_alloc(cap);
+    size_t n;
+    while ((n = fread(buf + len, 1, cap - len - 1, fp)) > 0) {
+        len += n;
+        if (len + 1 >= cap) {
+            cap *= 2;
+            buf = (char *)urus_realloc(buf, cap);
+        }
+    }
+    pclose(fp);
+    buf[len] = '\0';
+    urus_str *result = urus_str_new(buf, len);
+    free(buf);
+    return result;
+}
+
+static urus_str *urus_http_post(urus_str *url, urus_str *body) {
+    char cmd[8192];
+    snprintf(cmd, sizeof(cmd), "curl -s -X POST -d \"%s\" \"%s\"", body->data, url->data);
+    FILE *fp = popen(cmd, "r");
+    if (!fp) {
+        fprintf(stderr, "Error: failed to execute curl\n");
+        return urus_str_from("");
+    }
+    size_t cap = 4096;
+    size_t len = 0;
+    char *buf = (char *)urus_alloc(cap);
+    size_t n;
+    while ((n = fread(buf + len, 1, cap - len - 1, fp)) > 0) {
+        len += n;
+        if (len + 1 >= cap) {
+            cap *= 2;
+            buf = (char *)urus_realloc(buf, cap);
+        }
+    }
+    pclose(fp);
+    buf[len] = '\0';
+    urus_str *result = urus_str_new(buf, len);
+    free(buf);
+    return result;
+}
+
 #endif

--- a/compiler/src/Sema/builtins.c
+++ b/compiler/src/Sema/builtins.c
@@ -67,6 +67,10 @@ void sema_register_builtins(SemaScope *global) {
     add_builtin(global, "write_file",  T_VOID, 2, "path", T_STR, "content", T_STR);
     add_builtin(global, "append_file", T_VOID, 2, "path", T_STR, "content", T_STR);
 
+    // HTTP
+    add_builtin(global, "http_get",  T_STR,  1, "url", T_STR);
+    add_builtin(global, "http_post", T_STR,  2, "url", T_STR, "body", T_STR);
+
     add_builtin(global, "exit",   T_VOID, 1, "code", T_INT);
     add_builtin(global, "assert", T_VOID, 2, "cond", T_BOOL, "msg", T_STR);
 

--- a/compiler/src/codegen.c
+++ b/compiler/src/codegen.c
@@ -492,6 +492,8 @@ static void gen_expr(CodeBuf *buf, AstNode *node) {
             {"read_file",      "urus_read_file"},
             {"write_file",     "urus_write_file"},
             {"append_file",    "urus_append_file"},
+            {"http_get",       "urus_http_get"},
+            {"http_post",      "urus_http_post"},
             {"exit",           "urus_exit"},
             {"assert",         "urus_assert"},
             {"len",            "urus_len"},


### PR DESCRIPTION
## Summary
- Add `http_get(url)` and `http_post(url, body)` built-in functions
- Uses `curl` CLI via `popen()` as portable backend
- Registered in sema builtins and mapped in codegen
- Returns response body as `str`

### Usage
```urus
fn main(): void {
    let res = http_get("https://httpbin.org/get");
    print(res);

    let post_res = http_post("https://httpbin.org/post", "{\"key\": \"value\"}");
    print(post_res);
}
```

Closes #87

Co-authored with @billalxcode (original feature request)

## Test plan
- [x] All 23 existing tests pass
- [x] Verified generated C code for http_get and http_post
- [x] Runtime functions compile correctly in generated C