### PR TITLE
fix: using non-c11 function, using `_POSIX_C_SOURCE` to fix this.

### DIFF
--- a/compiler/include/urus_runtime.h
+++ b/compiler/include/urus_runtime.h
@@ -1,6 +1,10 @@
 #ifndef URUS_RUNTIME_H
 #define URUS_RUNTIME_H
 
+#ifndef _WIN32
+#  define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>


### PR DESCRIPTION
`urus_runtime.h` is using non-c11 function in unix system like `popen`, i've added:

```c
#ifndef _WIN32
#    define _POSIX_C_SOURCE 2008909L
#endif
```

at the top of `urus_runtime.h` to fix this problem.