### PR TITLE
fix: address multiple security vulnerabilities

### DIFF
--- a/compiler/include/urus_runtime.h
+++ b/compiler/include/urus_runtime.h
@@ -548,11 +548,26 @@ static void urus_assert(bool cond, urus_str *msg) {
 // On Unix, we use popen with curl
 #endif
 
+static bool urus_http_validate_input(const char *s) {
+    for (const char *p = s; *p; p++) {
+        if (*p == '"' || *p == '`' || *p == '$' || *p == ';' ||
+            *p == '|' || *p == '&' || *p == '\\' || *p == '\n' || *p == '\r') {
+            return false;
+        }
+    }
+    return true;
+}
+
 static urus_str *urus_http_get(urus_str *url) {
-    // Use popen + curl as portable fallback
-    char cmd[4096];
-    snprintf(cmd, sizeof(cmd), "curl -s \"%s\"", url->data);
+    if (!urus_http_validate_input(url->data)) {
+        fprintf(stderr, "Error: http_get URL contains unsafe characters\n");
+        return urus_str_from("");
+    }
+    size_t cmd_len = url->len + 32;
+    char *cmd = (char *)urus_alloc(cmd_len);
+    snprintf(cmd, cmd_len, "curl -s \"%s\"", url->data);
     FILE *fp = popen(cmd, "r");
+    free(cmd);
     if (!fp) {
         fprintf(stderr, "Error: failed to execute curl\n");
         return urus_str_from("");
@@ -576,9 +591,15 @@ static urus_str *urus_http_get(urus_str *url) {
 }
 
 static urus_str *urus_http_post(urus_str *url, urus_str *body) {
-    char cmd[8192];
-    snprintf(cmd, sizeof(cmd), "curl -s -X POST -d \"%s\" \"%s\"", body->data, url->data);
+    if (!urus_http_validate_input(url->data) || !urus_http_validate_input(body->data)) {
+        fprintf(stderr, "Error: http_post URL or body contains unsafe characters\n");
+        return urus_str_from("");
+    }
+    size_t cmd_len = url->len + body->len + 64;
+    char *cmd = (char *)urus_alloc(cmd_len);
+    snprintf(cmd, cmd_len, "curl -s -X POST -d \"%s\" \"%s\"", body->data, url->data);
     FILE *fp = popen(cmd, "r");
+    free(cmd);
     if (!fp) {
         fprintf(stderr, "Error: failed to execute curl\n");
         return urus_str_from("");

--- a/compiler/src/codegen.c
+++ b/compiler/src/codegen.c
@@ -437,6 +437,7 @@ static void gen_expr(CodeBuf *buf, AstNode *node) {
         break;
     case NODE_BINARY:
         if ((node->as.binary.op == TOK_EQ || node->as.binary.op == TOK_NEQ) &&
+                node->as.binary.left->resolved_type &&
                 node->as.binary.left->resolved_type->kind == TYPE_STR) {
             emit(buf, "(%surus_%s_equal(", node->as.binary.op == TOK_EQ ? "" : "!",
                     ast_type_str(node->as.binary.left->resolved_type));
@@ -747,7 +748,8 @@ static int gen_expr_pre(CodeBuf *buf, AstNode *node) {
             emit(buf, "_urus_en_%d->data.%s.f%d = ", tmp, vname, i);
             gen_expr(buf, node->as.enum_init.args[i]);
             emit(buf, ";\n");
-            if (type_needs_rc(node->as.enum_init.args[i]->resolved_type) &&
+            if (node->as.enum_init.args[i]->resolved_type &&
+                    type_needs_rc(node->as.enum_init.args[i]->resolved_type) &&
                     node->as.enum_init.args[i]->kind == NODE_IDENT) {
                 emit_indent(buf);
                 emit(buf, "%s = NULL; // move to enum variant\n", node->as.enum_init.args[i]->as.ident.name);

--- a/compiler/src/parser.c
+++ b/compiler/src/parser.c
@@ -400,8 +400,8 @@ static AstNode *parse_primary(Parser *p) {
                     }
 
                     // Build expanded token stream: substitute params with arg tokens
-                    int exp_cap = rune->body_token_count * 2 + 16;
-                    Token *expanded = malloc(sizeof(Token) * (size_t)exp_cap);
+                    size_t exp_cap = (size_t)rune->body_token_count * 2 + 16;
+                    Token *expanded = malloc(sizeof(Token) * exp_cap);
                     int exp_count = 0;
 
                     for (int i = 0; i < rune->body_token_count; i++) {
@@ -412,10 +412,10 @@ static AstNode *parse_primary(Parser *p) {
                                 if (bt.length == strlen(rune->param_names[j]) &&
                                     memcmp(bt.start, rune->param_names[j], bt.length) == 0) {
                                     // Replace this token with the argument's tokens
-                                    int needed = exp_count + arg_lens[j] + 1;
+                                    size_t needed = (size_t)exp_count + (size_t)arg_lens[j] + 1;
                                     if (needed >= exp_cap) {
                                         exp_cap = needed * 2;
-                                        expanded = realloc(expanded, sizeof(Token) * (size_t)exp_cap);
+                                        expanded = realloc(expanded, sizeof(Token) * exp_cap);
                                     }
                                     for (int k = 0; k < arg_lens[j]; k++) {
                                         expanded[exp_count++] = arg_tokens[j][k];
@@ -426,18 +426,18 @@ static AstNode *parse_primary(Parser *p) {
                             }
                         }
                         if (!substituted) {
-                            if (exp_count >= exp_cap) {
+                            if ((size_t)exp_count >= exp_cap) {
                                 exp_cap *= 2;
-                                expanded = realloc(expanded, sizeof(Token) * (size_t)exp_cap);
+                                expanded = realloc(expanded, sizeof(Token) * exp_cap);
                             }
                             expanded[exp_count++] = bt;
                         }
                     }
 
                     // Add EOF token
-                    if (exp_count >= exp_cap) {
+                    if ((size_t)exp_count >= exp_cap) {
                         exp_cap++;
-                        expanded = realloc(expanded, sizeof(Token) * (size_t)exp_cap);
+                        expanded = realloc(expanded, sizeof(Token) * exp_cap);
                     }
                     Token eof_tok = {TOK_EOF, "", 0, t.line, t.col};
                     expanded[exp_count++] = eof_tok;


### PR DESCRIPTION
## Summary

Fixes multiple security vulnerabilities found during compiler & runtime audit (#100):

- **Command injection in HTTP builtins**: `http_get`/`http_post` now validate URLs and bodies for shell metacharacters (`"`, `` ` ``, `$`, `;`, `|`, `&`, `\`) before passing to `popen(curl)`. Also switched from fixed-size buffers to dynamic allocation to prevent truncation on long URLs.
- **NULL pointer dereference in codegen**: Added guards for `resolved_type` being NULL in binary expression and enum init code generation paths.
- **Integer overflow in rune expansion**: Changed capacity tracking from `int` to `size_t` to prevent overflow when expanding large rune macros.

## Test plan

- [x] All existing tests compile with `--emit-c`
- [x] Bitwise, rune, enum, and result examples verified
- [x] Build passes on MSVC (Windows)
