### PR TITLE
feat: add const declarations

### DIFF
--- a/compiler/include/ast.h
+++ b/compiler/include/ast.h
@@ -79,6 +79,7 @@ typedef enum {
     NODE_TUPLE_LIT,   // (expr1, expr2, ...)
     NODE_IF_EXPR,     // if cond { expr } else { expr } (expression context)
     NODE_RUNE_DECL,   // rune name(params) { body }
+    NODE_CONST_DECL,  // const NAME: type = value;
 } NodeKind;
 
 // ---- Param ----
@@ -285,6 +286,13 @@ struct AstNode {
             Token *body_tokens;
             int body_token_count;
         } rune_decl;
+
+        // NODE_CONST_DECL
+        struct {
+            char *name;
+            AstType *type;
+            AstNode *value;
+        } const_decl;
     } as;
 
     // Filled by semantic analysis

--- a/compiler/include/token.h
+++ b/compiler/include/token.h
@@ -30,6 +30,7 @@ typedef enum {
     TOK_MATCH,
     TOK_IMPORT,
     TOK_RUNE,
+    TOK_CONST,
 
     // Type keywords
     TOK_INT,

--- a/compiler/src/Sema/sema.c
+++ b/compiler/src/Sema/sema.c
@@ -876,6 +876,25 @@ bool sema_analyze(AstNode *program, const char *filename) {
             s->params = d->as.fn_decl.params;
             s->param_count = d->as.fn_decl.param_count;
             s->return_type = d->as.fn_decl.return_type;
+        } else if (d->kind == NODE_CONST_DECL) {
+            if (scope_lookup_local(global, d->as.const_decl.name)) {
+                sema_error(&ctx, &d->tok, "duplicate constant '%s'", d->as.const_decl.name);
+                continue;
+            }
+            AstNode *val = d->as.const_decl.value;
+            if (val->kind != NODE_INT_LIT && val->kind != NODE_FLOAT_LIT &&
+                val->kind != NODE_STR_LIT && val->kind != NODE_BOOL_LIT) {
+                sema_error(&ctx, &val->tok, "const value must be a literal");
+            }
+            AstType *vt = check_expr(&ctx, val);
+            if (vt && d->as.const_decl.type && !ast_types_equal(vt, d->as.const_decl.type)) {
+                sema_error(&ctx, &val->tok, "const type mismatch: expected '%s', got '%s'",
+                           ast_type_str(d->as.const_decl.type), ast_type_str(vt));
+            }
+            SemaSymbol *s = scope_add(global, d->as.const_decl.name, d->tok);
+            s->type = d->as.const_decl.type;
+            s->is_mut = false;
+            s->is_referenced = true; // don't warn unused for constants
         }
     }
 

--- a/compiler/src/ast.c
+++ b/compiler/src/ast.c
@@ -447,6 +447,10 @@ void ast_print(AstNode *node, int ind) {
                node->as.rune_decl.name, node->as.rune_decl.param_count,
                node->as.rune_decl.body_token_count);
         break;
+    case NODE_CONST_DECL:
+        printf("ConstDecl '%s'\n", node->as.const_decl.name);
+        ast_print(node->as.const_decl.value, ind + 1);
+        break;
     }
 }
 
@@ -655,6 +659,11 @@ void ast_free(AstNode *node) {
             free(node->as.rune_decl.param_names[i]);
         free(node->as.rune_decl.param_names);
         free(node->as.rune_decl.body_tokens);
+        break;
+    case NODE_CONST_DECL:
+        free(node->as.const_decl.name);
+        ast_type_free(node->as.const_decl.type);
+        ast_free(node->as.const_decl.value);
         break;
     case NODE_INT_LIT:
     case NODE_FLOAT_LIT:

--- a/compiler/src/codegen.c
+++ b/compiler/src/codegen.c
@@ -1236,6 +1236,23 @@ void codegen_generate(CodeBuf *buf, AstNode *program) {
             emit(buf, "typedef struct %s %s;\n", d->as.enum_decl.name, d->as.enum_decl.name);
         }
     }
+
+    // Const declarations
+    for (int i = 0; i < program->as.program.decl_count; i++) {
+        AstNode *d = program->as.program.decls[i];
+        if (d->kind == NODE_CONST_DECL) {
+            AstNode *val = d->as.const_decl.value;
+            if (val->kind == NODE_INT_LIT) {
+                emit(buf, "#define %s ((int64_t)%lld)\n", d->as.const_decl.name, val->as.int_lit.value);
+            } else if (val->kind == NODE_FLOAT_LIT) {
+                emit(buf, "#define %s ((double)%g)\n", d->as.const_decl.name, val->as.float_lit.value);
+            } else if (val->kind == NODE_BOOL_LIT) {
+                emit(buf, "#define %s %s\n", d->as.const_decl.name, val->as.bool_lit.value ? "true" : "false");
+            } else if (val->kind == NODE_STR_LIT) {
+                emit(buf, "static urus_str *%s;\n", d->as.const_decl.name);
+            }
+        }
+    }
     emit(buf, "\n");
 
     // Pass 2: struct definitions
@@ -1364,23 +1381,36 @@ void codegen_generate(CodeBuf *buf, AstNode *program) {
 
     if (main_has_args) {
         emit(buf,
-            "int main(int argc, char **argv) {\n"
+            "int main(int argc, char **argv) {\n");
+    } else {
+        emit(buf,
+            "int main() {\n");
+    }
+
+    // Initialize string constants
+    for (int i = 0; i < program->as.program.decl_count; i++) {
+        AstNode *d = program->as.program.decls[i];
+        if (d->kind == NODE_CONST_DECL && d->as.const_decl.value->kind == NODE_STR_LIT) {
+            emit(buf, "   %s = urus_str_from(\"%s\");\n",
+                 d->as.const_decl.name, d->as.const_decl.value->as.str_lit.value);
+        }
+    }
+
+    if (main_has_args) {
+        emit(buf,
             "   urus_array *_urus_argv = urus_array_new(sizeof(urus_str *), (size_t)argc, (urus_drop_fn)urus_str_drop);\n"
             "   for (int i = 0; i < argc; i++) {\n"
             "       urus_str *s = urus_str_from(argv[i]);\n"
             "       urus_array_push(_urus_argv, &s);\n"
             "   }\n"
             "   urus_main((int64_t)argc, _urus_argv);\n"
-            "   urus_array_drop(&_urus_argv);\n"
-            "   return 0;\n"
-            "}\n"
-        );
+            "   urus_array_drop(&_urus_argv);\n");
     } else {
         emit(buf,
-            "int main() {\n"
-            "   urus_main();\n"
-            "   return 0;\n"
-            "}\n"
-        );
+            "   urus_main();\n");
     }
+
+    emit(buf,
+        "   return 0;\n"
+        "}\n");
 }

--- a/compiler/src/lexer.c
+++ b/compiler/src/lexer.c
@@ -82,6 +82,7 @@ static TokenType check_keyword(const char *start, size_t len) {
         {"match",    5, TOK_MATCH},
         {"import",   6, TOK_IMPORT},
         {"rune",     4, TOK_RUNE},
+        {"const",    5, TOK_CONST},
         {"int",      3, TOK_INT},
         {"float",    5, TOK_FLOAT},
         {"bool",     4, TOK_BOOL},
@@ -346,6 +347,7 @@ const char *token_type_name(TokenType type) {
     case TOK_MATCH: return "MATCH";
     case TOK_IMPORT: return "IMPORT";
     case TOK_RUNE: return "RUNE";
+    case TOK_CONST: return "CONST";
     case TOK_ARROW: return "ARROW";
     case TOK_INT: return "INT";
     case TOK_FLOAT: return "FLOAT";

--- a/compiler/src/parser.c
+++ b/compiler/src/parser.c
@@ -1330,12 +1330,29 @@ static AstNode *parse_rune_decl(Parser *p) {
     return n;
 }
 
+static AstNode *parse_const_decl(Parser *p) {
+    Token t = expect(p, TOK_CONST, "expected 'const'");
+    Token name = expect(p, TOK_IDENT, "expected constant name");
+    expect(p, TOK_COLON, "expected ':' after constant name");
+    AstType *type = parse_type(p);
+    expect(p, TOK_ASSIGN, "expected '=' in const declaration");
+    AstNode *value = parse_expr(p);
+    expect(p, TOK_SEMICOLON, "expected ';' after const declaration");
+
+    AstNode *n = ast_new(NODE_CONST_DECL, t);
+    n->as.const_decl.name = tok_str(name);
+    n->as.const_decl.type = type;
+    n->as.const_decl.value = value;
+    return n;
+}
+
 static AstNode *parse_declaration(Parser *p) {
     if (check(p, TOK_FN)) return parse_fn_decl(p);
     if (check(p, TOK_STRUCT)) return parse_struct_decl(p);
     if (check(p, TOK_ENUM)) return parse_enum_decl(p);
     if (check(p, TOK_IMPORT)) return parse_import(p);
     if (check(p, TOK_RUNE)) return parse_rune_decl(p);
+    if (check(p, TOK_CONST)) return parse_const_decl(p);
     return parse_statement(p);
 }
 

--- a/tests/run/const.expected
+++ b/tests/run/const.expected
@@ -1,0 +1,6 @@
+App: TestApp
+PI: 3.14159
+Max: 100
+release mode
+Area: 78.53975
+big

--- a/tests/run/const.urus
+++ b/tests/run/const.urus
@@ -1,0 +1,22 @@
+const PI: float = 3.14159;
+const MAX_SIZE: int = 100;
+const APP_NAME: str = "TestApp";
+const DEBUG: bool = false;
+
+fn main(): void {
+    print(f"App: {APP_NAME}");
+    print(f"PI: {PI}");
+    print(f"Max: {MAX_SIZE}");
+    if DEBUG {
+        print("debug mode");
+    } else {
+        print("release mode");
+    }
+
+    let area: float = PI * 5.0 * 5.0;
+    print(f"Area: {area}");
+
+    if MAX_SIZE > 50 {
+        print("big");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `const` keyword for compile-time constant declarations (#102)
- Supports `int`, `float`, `bool`, `str` literal values
- Int/float/bool constants emit as C `#define` macros (zero overhead)
- String constants emit as `static urus_str*` initialized in `main()`
- Sema validates that const values are literals and types match

## Test plan

- [x] `tests/run/const.urus` — all 4 types, used in expressions and conditions
- [x] Existing tests still pass (bitwise, runes, enums, etc.)
