### PR TITLE
feat: add string method-call syntax

### DIFF
--- a/compiler/src/Sema/sema.c
+++ b/compiler/src/Sema/sema.c
@@ -186,10 +186,14 @@ static AstType *check_expr(SemaCtx *ctx, AstNode *node) {
             const char *method = node->as.call.callee->as.field_access.field;
             AstType *obj_type = check_expr(ctx, obj);
 
-            if (obj_type && obj_type->kind == TYPE_NAMED) {
-                // Look for StructName_method
+            if (obj_type && (obj_type->kind == TYPE_NAMED || obj_type->kind == TYPE_STR)) {
+                // Build the function name: StructName_method or str_method
                 char fn_name_buf[256];
-                snprintf(fn_name_buf, sizeof(fn_name_buf), "%s_%s", obj_type->name, method);
+                if (obj_type->kind == TYPE_STR) {
+                    snprintf(fn_name_buf, sizeof(fn_name_buf), "str_%s", method);
+                } else {
+                    snprintf(fn_name_buf, sizeof(fn_name_buf), "%s_%s", obj_type->name, method);
+                }
                 SemaSymbol *method_sym = scope_lookup(ctx->current, fn_name_buf);
 
                 if (method_sym && method_sym->is_fn) {
@@ -208,7 +212,7 @@ static AstType *check_expr(SemaCtx *ctx, AstNode *node) {
                     // Fall through to normal call checking below
                 } else {
                     sema_error(ctx, &node->tok, "no method '%s' on type '%s'",
-                               method, obj_type->name);
+                               method, obj_type->kind == TYPE_STR ? "str" : obj_type->name);
                     for (int i = 0; i < node->as.call.arg_count; i++)
                         check_expr(ctx, node->as.call.args[i]);
                     return set_type(node, ast_type_simple(TYPE_VOID));

--- a/tests/run/str_methods.expected
+++ b/tests/run/str_methods.expected
@@ -1,0 +1,11 @@
+Hello, World!
+HELLO, WORLD!
+hello, world!
+13
+true
+6
+hello
+hello urus
+true
+true
+urus language

--- a/tests/run/str_methods.urus
+++ b/tests/run/str_methods.urus
@@ -1,0 +1,21 @@
+fn main(): void {
+    let s: str = "  Hello, World!  ";
+
+    // Method syntax
+    print(s.trim());
+    print(s.trim().upper());
+    print(s.trim().lower());
+    print(to_str(s.trim().len()));
+
+    let name: str = "hello world";
+    print(to_str(name.contains("world")));
+    print(to_str(name.find("world")));
+    print(name.slice(0, 5));
+    print(name.replace("world", "urus"));
+    print(to_str(name.starts_with("hello")));
+    print(to_str(name.ends_with("world")));
+
+    // Chaining
+    let result: str = "  URUS Language  ".trim().lower();
+    print(result);
+}


### PR DESCRIPTION
## Summary

- Add method-call syntax for string operations (#104)
- `s.upper()`, `s.trim()`, `s.len()`, `s.contains(x)`, `s.slice(0, 5)`, etc.
- Chainable: `"  HELLO  ".trim().lower()` works
- Pure syntactic sugar — sema desugars `s.method(args)` into `str_method(s, args)`
- No new AST nodes or codegen changes needed

## Test plan

- [x] `tests/run/str_methods.urus` — all 11 string methods + chaining
- [x] Existing string tests still pass
