### PR TITLE
feat: extended match for int/str/bool patterns

### DIFF
--- a/compiler/src/Sema/sema.c
+++ b/compiler/src/Sema/sema.c
@@ -798,59 +798,86 @@ static void check_stmt(SemaCtx *ctx, AstNode *node) {
 
     case NODE_MATCH: {
         AstType *target_type = check_expr(ctx, node->as.match_stmt.target);
-        if (!target_type || target_type->kind != TYPE_NAMED) {
-            sema_error(ctx, &node->as.match_stmt.target->tok, "match target must be an enum type, got '%s'",
-                       ast_type_str(target_type));
-            break;
-        }
-        SemaSymbol *enum_sym = scope_lookup(ctx->current, target_type->name);
-        if (!enum_sym || !enum_sym->is_enum) {
-            sema_error(ctx, &node->as.match_stmt.target->tok, "match target type '%s' is not an enum", target_type->name);
-            break;
-        }
+        if (!target_type) break;
 
-        for (int i = 0; i < node->as.match_stmt.arm_count; i++) {
-            MatchArm *arm = &node->as.match_stmt.arms[i];
-            // Find variant
-            EnumVariant *variant = NULL;
-            for (int v = 0; v < enum_sym->variant_count; v++) {
-                if (strcmp(enum_sym->variants[v].name, arm->variant_name) == 0) {
-                    variant = &enum_sym->variants[v];
-                    break;
+        // Determine if this is a primitive match (int/str/bool) or enum match
+        bool is_primitive = (target_type->kind == TYPE_INT || target_type->kind == TYPE_STR ||
+                             target_type->kind == TYPE_BOOL);
+
+        if (is_primitive) {
+            // Primitive match: arms are literals or _
+            for (int i = 0; i < node->as.match_stmt.arm_count; i++) {
+                MatchArm *arm = &node->as.match_stmt.arms[i];
+                if (!arm->is_wildcard && arm->pattern_expr) {
+                    AstType *pat_type = check_expr(ctx, arm->pattern_expr);
+                    if (pat_type && !ast_types_equal(pat_type, target_type)) {
+                        sema_error(ctx, &arm->pattern_expr->tok,
+                                   "match arm pattern type '%s' does not match target type '%s'",
+                                   ast_type_str(pat_type), ast_type_str(target_type));
+                    }
+                }
+                // Check arm body
+                AstNode *arm_body = arm->body;
+                for (int s = 0; s < arm_body->as.block.stmt_count; s++) {
+                    check_stmt(ctx, arm_body->as.block.stmts[s]);
                 }
             }
-            if (!variant) {
-                sema_error(ctx, &node->as.match_stmt.target->tok, "enum '%s' has no variant '%s'",
-                           target_type->name, arm->variant_name);
-                continue;
-            }
-            if (arm->binding_count != variant->field_count) {
-                sema_error(ctx, &node->as.match_stmt.target->tok, "variant '%s' has %d fields, got %d bindings",
-                           arm->variant_name, variant->field_count, arm->binding_count);
+        } else if (target_type->kind == TYPE_NAMED) {
+            // Enum match
+            SemaSymbol *enum_sym = scope_lookup(ctx->current, target_type->name);
+            if (!enum_sym || !enum_sym->is_enum) {
+                sema_error(ctx, &node->as.match_stmt.target->tok,
+                           "match target type '%s' is not an enum", target_type->name);
+                break;
             }
 
-            // Store binding types for codegen
-            if (arm->binding_count > 0) {
-                arm->binding_types = malloc(sizeof(AstType *) * (size_t)arm->binding_count);
+            for (int i = 0; i < node->as.match_stmt.arm_count; i++) {
+                MatchArm *arm = &node->as.match_stmt.arms[i];
+                // Find variant
+                EnumVariant *variant = NULL;
+                for (int v = 0; v < enum_sym->variant_count; v++) {
+                    if (strcmp(enum_sym->variants[v].name, arm->variant_name) == 0) {
+                        variant = &enum_sym->variants[v];
+                        break;
+                    }
+                }
+                if (!variant) {
+                    sema_error(ctx, &node->as.match_stmt.target->tok, "enum '%s' has no variant '%s'",
+                               target_type->name, arm->variant_name);
+                    continue;
+                }
+                if (arm->binding_count != variant->field_count) {
+                    sema_error(ctx, &node->as.match_stmt.target->tok, "variant '%s' has %d fields, got %d bindings",
+                               arm->variant_name, variant->field_count, arm->binding_count);
+                }
+
+                // Store binding types for codegen
+                if (arm->binding_count > 0) {
+                    arm->binding_types = malloc(sizeof(AstType *) * (size_t)arm->binding_count);
+                    for (int b = 0; b < arm->binding_count && b < variant->field_count; b++) {
+                        arm->binding_types[b] = ast_type_clone(variant->fields[b].type);
+                    }
+                }
+
+                // Check arm body with bindings in scope
+                SemaScope *arm_scope = scope_new(ctx->current);
+                ctx->current = arm_scope;
                 for (int b = 0; b < arm->binding_count && b < variant->field_count; b++) {
-                    arm->binding_types[b] = ast_type_clone(variant->fields[b].type);
+                    SemaSymbol *binding = scope_add(arm_scope, arm->bindings[b], node->tok);
+                    binding->type = ast_type_clone(variant->fields[b].type);
+                    binding->is_mut = false;
                 }
+                AstNode *arm_body = arm->body;
+                for (int s = 0; s < arm_body->as.block.stmt_count; s++) {
+                    check_stmt(ctx, arm_body->as.block.stmts[s]);
+                }
+                ctx->current = arm_scope->parent;
+                scope_free(arm_scope);
             }
-
-            // Check arm body with bindings in scope
-            SemaScope *arm_scope = scope_new(ctx->current);
-            ctx->current = arm_scope;
-            for (int b = 0; b < arm->binding_count && b < variant->field_count; b++) {
-                SemaSymbol *binding = scope_add(arm_scope, arm->bindings[b], node->tok);
-                binding->type = ast_type_clone(variant->fields[b].type);
-                binding->is_mut = false;
-            }
-            AstNode *arm_body = arm->body;
-            for (int s = 0; s < arm_body->as.block.stmt_count; s++) {
-                check_stmt(ctx, arm_body->as.block.stmts[s]);
-            }
-            ctx->current = arm_scope->parent;
-            scope_free(arm_scope);
+        } else {
+            sema_error(ctx, &node->as.match_stmt.target->tok,
+                       "match target must be an enum, int, str, or bool type, got '%s'",
+                       ast_type_str(target_type));
         }
         break;
     }

--- a/compiler/src/ast.c
+++ b/compiler/src/ast.c
@@ -397,16 +397,23 @@ void ast_print(AstNode *node, int ind) {
         ast_print(node->as.match_stmt.target, ind + 2);
         for (int i = 0; i < node->as.match_stmt.arm_count; i++) {
             MatchArm *a = &node->as.match_stmt.arms[i];
-            indent(ind + 1); printf("arm %s.%s", a->enum_name, a->variant_name);
-            if (a->binding_count > 0) {
-                printf("(");
-                for (int j = 0; j < a->binding_count; j++) {
-                    if (j > 0) printf(", ");
-                    printf("%s", a->bindings[j]);
+            indent(ind + 1);
+            if (a->is_wildcard) {
+                printf("arm _ =>\n");
+            } else if (a->pattern_expr) {
+                printf("arm <literal> =>\n");
+            } else {
+                printf("arm %s.%s", a->enum_name, a->variant_name);
+                if (a->binding_count > 0) {
+                    printf("(");
+                    for (int j = 0; j < a->binding_count; j++) {
+                        if (j > 0) printf(", ");
+                        printf("%s", a->bindings[j]);
+                    }
+                    printf(")");
                 }
-                printf(")");
+                printf(" =>\n");
             }
-            printf(" =>\n");
             ast_print(a->body, ind + 2);
         }
         break;

--- a/compiler/src/codegen.c
+++ b/compiler/src/codegen.c
@@ -1121,44 +1121,87 @@ static void gen_stmt(CodeBuf *buf, AstNode *node) {
         break;
     case NODE_MATCH: {
         gen_expr_pre(buf, node->as.match_stmt.target);
-        // Store target in temp
         int tmp = buf->tmp_counter++;
-        emit_indent(buf);
-        // Determine enum type name from first arm
-        const char *ename = "";
-        if (node->as.match_stmt.arm_count > 0) {
-            ename = node->as.match_stmt.arms[0].enum_name;
-        }
-        emit(buf, "%s* _urus_match_%d = ", ename, tmp);
-        gen_expr(buf, node->as.match_stmt.target);
-        emit(buf, ";\n");
+        AstType *target_type = node->as.match_stmt.target->resolved_type;
+        bool is_primitive = target_type && (target_type->kind == TYPE_INT ||
+                            target_type->kind == TYPE_STR || target_type->kind == TYPE_BOOL);
 
-        for (int i = 0; i < node->as.match_stmt.arm_count; i++) {
-            MatchArm *arm = &node->as.match_stmt.arms[i];
+        if (is_primitive) {
+            // Primitive match: store target in temp variable
             emit_indent(buf);
-            if (i == 0) emit(buf, "if ");
-            else emit(buf, "else if ");
-            emit(buf, "(_urus_match_%d->tag == %s_TAG_%s) ", tmp, arm->enum_name, arm->variant_name);
-            emit(buf, "{\n");
-            buf->indent++;
-            // Bind variant fields
-            for (int b = 0; b < arm->binding_count; b++) {
+            gen_type(buf, target_type);
+            emit(buf, " _urus_match_%d = ", tmp);
+            gen_expr(buf, node->as.match_stmt.target);
+            emit(buf, ";\n");
+
+            bool first = true;
+            for (int i = 0; i < node->as.match_stmt.arm_count; i++) {
+                MatchArm *arm = &node->as.match_stmt.arms[i];
                 emit_indent(buf);
-                if (arm->binding_types && arm->binding_types[b]) {
-                    gen_type(buf, arm->binding_types[b]);
+                if (arm->is_wildcard) {
+                    if (!first) emit(buf, "else ");
+                    emit(buf, "{\n");
                 } else {
-                    emit(buf, "int64_t");
+                    if (first) emit(buf, "if (");
+                    else emit(buf, "else if (");
+
+                    if (target_type->kind == TYPE_STR) {
+                        emit(buf, "urus_str_equal(_urus_match_%d, ", tmp);
+                        gen_expr(buf, arm->pattern_expr);
+                        emit(buf, ")");
+                    } else {
+                        emit(buf, "_urus_match_%d == ", tmp);
+                        gen_expr(buf, arm->pattern_expr);
+                    }
+                    emit(buf, ") {\n");
+                    first = false;
                 }
-                emit(buf, " %s = _urus_match_%d->data.%s.f%d;\n",
-                     arm->bindings[b], tmp, arm->variant_name, b);
+                buf->indent++;
+                for (int s = 0; s < arm->body->as.block.stmt_count; s++) {
+                    gen_stmt(buf, arm->body->as.block.stmts[s]);
+                }
+                buf->indent--;
+                emit_indent(buf);
+                emit(buf, "}\n");
             }
-            // Emit body statements
-            for (int s = 0; s < arm->body->as.block.stmt_count; s++) {
-                gen_stmt(buf, arm->body->as.block.stmts[s]);
-            }
-            buf->indent--;
+        } else {
+            // Enum match
             emit_indent(buf);
-            emit(buf, "}\n");
+            const char *ename = "";
+            if (node->as.match_stmt.arm_count > 0 && node->as.match_stmt.arms[0].enum_name) {
+                ename = node->as.match_stmt.arms[0].enum_name;
+            }
+            emit(buf, "%s* _urus_match_%d = ", ename, tmp);
+            gen_expr(buf, node->as.match_stmt.target);
+            emit(buf, ";\n");
+
+            for (int i = 0; i < node->as.match_stmt.arm_count; i++) {
+                MatchArm *arm = &node->as.match_stmt.arms[i];
+                emit_indent(buf);
+                if (i == 0) emit(buf, "if ");
+                else emit(buf, "else if ");
+                emit(buf, "(_urus_match_%d->tag == %s_TAG_%s) ", tmp, arm->enum_name, arm->variant_name);
+                emit(buf, "{\n");
+                buf->indent++;
+                // Bind variant fields
+                for (int b = 0; b < arm->binding_count; b++) {
+                    emit_indent(buf);
+                    if (arm->binding_types && arm->binding_types[b]) {
+                        gen_type(buf, arm->binding_types[b]);
+                    } else {
+                        emit(buf, "int64_t");
+                    }
+                    emit(buf, " %s = _urus_match_%d->data.%s.f%d;\n",
+                         arm->bindings[b], tmp, arm->variant_name, b);
+                }
+                // Emit body statements
+                for (int s = 0; s < arm->body->as.block.stmt_count; s++) {
+                    gen_stmt(buf, arm->body->as.block.stmts[s]);
+                }
+                buf->indent--;
+                emit_indent(buf);
+                emit(buf, "}\n");
+            }
         }
         break;
     }

--- a/compiler/src/parser.c
+++ b/compiler/src/parser.c
@@ -30,6 +30,11 @@ static bool check(Parser *p, TokenType type) {
     return current(p).type == type;
 }
 
+static TokenType peek_next_type(Parser *p) {
+    if (p->tokens[p->pos].type == TOK_EOF) return TOK_EOF;
+    return p->tokens[p->pos + 1].type;
+}
+
 static bool at_end(Parser *p) {
     return current(p).type == TOK_EOF;
 }
@@ -1015,31 +1020,54 @@ static AstNode *parse_match(Parser *p) {
             cap *= 2;
             arms = realloc(arms, sizeof(MatchArm) * (size_t)cap);
         }
-        Token enum_tok = expect(p, TOK_IDENT, "expected enum name in match arm");
-        expect(p, TOK_DOT, "expected '.' after enum name");
-        Token var_tok = expect(p, TOK_IDENT, "expected variant name");
 
-        arms[count].enum_name = tok_str(enum_tok);
-        arms[count].variant_name = tok_str(var_tok);
+        // Initialize arm defaults
+        arms[count].enum_name = NULL;
+        arms[count].variant_name = NULL;
         arms[count].bindings = NULL;
         arms[count].binding_count = 0;
+        arms[count].binding_types = NULL;
+        arms[count].is_wildcard = false;
+        arms[count].pattern_expr = NULL;
 
-        if (match(p, TOK_LPAREN)) {
-            int bcap = 4, bcount = 0;
-            char **bindings = malloc(sizeof(char *) * (size_t)bcap);
-            if (!check(p, TOK_RPAREN)) {
-                do {
-                    if (bcount >= bcap) {
-                        bcap *= 2;
-                        bindings = realloc(bindings, sizeof(char *) * (size_t)bcap);
-                    }
-                    Token b = expect(p, TOK_IDENT, "expected binding name");
-                    bindings[bcount++] = tok_str(b);
-                } while (match(p, TOK_COMMA));
+        // Check what kind of pattern this is
+        if (check(p, TOK_INT_LIT) || check(p, TOK_STR_LIT) || check(p, TOK_TRUE) || check(p, TOK_FALSE)) {
+            // Literal pattern: 42, "hello", true, false
+            arms[count].pattern_expr = parse_primary(p);
+        } else if (check(p, TOK_MINUS) && peek_next_type(p) == TOK_INT_LIT) {
+            // Negative integer literal: -1
+            arms[count].pattern_expr = parse_unary(p);
+        } else if (check(p, TOK_IDENT) && current(p).length == 1 && current(p).start[0] == '_' &&
+                   peek_next_type(p) == TOK_ARROW) {
+            // Wildcard: _
+            advance_tok(p); // consume '_'
+            arms[count].is_wildcard = true;
+        } else {
+            // Enum pattern: EnumName.Variant or EnumName.Variant(bindings)
+            Token enum_tok = expect(p, TOK_IDENT, "expected pattern in match arm");
+            expect(p, TOK_DOT, "expected '.' after enum name");
+            Token var_tok = expect(p, TOK_IDENT, "expected variant name");
+
+            arms[count].enum_name = tok_str(enum_tok);
+            arms[count].variant_name = tok_str(var_tok);
+
+            if (match(p, TOK_LPAREN)) {
+                int bcap = 4, bcount = 0;
+                char **bindings = malloc(sizeof(char *) * (size_t)bcap);
+                if (!check(p, TOK_RPAREN)) {
+                    do {
+                        if (bcount >= bcap) {
+                            bcap *= 2;
+                            bindings = realloc(bindings, sizeof(char *) * (size_t)bcap);
+                        }
+                        Token b = expect(p, TOK_IDENT, "expected binding name");
+                        bindings[bcount++] = tok_str(b);
+                    } while (match(p, TOK_COMMA));
+                }
+                expect(p, TOK_RPAREN, "expected ')' after bindings");
+                arms[count].bindings = bindings;
+                arms[count].binding_count = bcount;
             }
-            expect(p, TOK_RPAREN, "expected ')' after bindings");
-            arms[count].bindings = bindings;
-            arms[count].binding_count = bcount;
         }
 
         expect(p, TOK_ARROW, "expected '=>' after match pattern");

--- a/tests/run/match_primitives.expected
+++ b/tests/run/match_primitives.expected
@@ -1,0 +1,10 @@
+zero
+one
+two
+other
+Hello!
+Halo!
+Konnichiwa!
+...
+yes
+no

--- a/tests/run/match_primitives.urus
+++ b/tests/run/match_primitives.urus
@@ -1,0 +1,39 @@
+fn describe(n: int): void {
+    match n {
+        0 => { print("zero"); }
+        1 => { print("one"); }
+        2 => { print("two"); }
+        _ => { print("other"); }
+    }
+}
+
+fn greet(lang: str): void {
+    match lang {
+        "en" => { print("Hello!"); }
+        "id" => { print("Halo!"); }
+        "jp" => { print("Konnichiwa!"); }
+        _ => { print("..."); }
+    }
+}
+
+fn check(b: bool): void {
+    match b {
+        true => { print("yes"); }
+        false => { print("no"); }
+    }
+}
+
+fn main(): void {
+    describe(0);
+    describe(1);
+    describe(2);
+    describe(99);
+
+    greet("en");
+    greet("id");
+    greet("jp");
+    greet("fr");
+
+    check(true);
+    check(false);
+}


### PR DESCRIPTION
## Summary
- Extends `match` statements to support primitive type patterns (int, str, bool), not just enum patterns
- Wildcard `_` arm support for default/catch-all cases
- Generates efficient if-else chains in C output, using `urus_str_equal()` for string comparisons

Closes #117

## Test plan
- [x] `tests/run/match_primitives.urus` covers int, str, and bool matching with wildcard arms
- [x] Verified `--emit-c` output generates correct C code
- [x] Existing tests still compile correctly