### PR TITLE
fix: address multiple security vulnerabilities

### DIFF
--- a/compiler/runtime/urus_runtime.h
+++ b/compiler/runtime/urus_runtime.h
@@ -142,6 +142,11 @@ static urus_str *urus_str_replace(urus_str *s, urus_str *old, urus_str *new_s) {
 
     // Use signed arithmetic to avoid unsigned underflow
     ptrdiff_t diff = (ptrdiff_t)new_s->len - (ptrdiff_t)old->len;
+    // Overflow check: ensure count * diff doesn't overflow
+    if (diff > 0 && count > (ptrdiff_t)((SIZE_MAX - s->len) / (size_t)diff)) {
+        fprintf(stderr, "Error: string replace result too large\n");
+        exit(1);
+    }
     size_t new_len = (size_t)((ptrdiff_t)s->len + count * diff);
     urus_str *r = (urus_str *)urus_alloc(sizeof(urus_str) + new_len + 1);
     r->len = new_len;
@@ -155,7 +160,9 @@ static urus_str *urus_str_replace(urus_str *s, urus_str *old, urus_str *new_s) {
         memcpy(dst, new_s->data, new_s->len); dst += new_s->len;
         p = q + old->len;
     }
-    strcpy(dst, p);
+    size_t remaining = strlen(p);
+    memcpy(dst, p, remaining);
+    dst[remaining] = '\0';
     return r;
 }
 

--- a/compiler/src/codegen.c
+++ b/compiler/src/codegen.c
@@ -36,6 +36,10 @@ static const char *tuple_type_name(AstType *t) {
     static char buf[512];
     int pos = snprintf(buf, sizeof(buf), "_urus_tuple");
     for (int i = 0; i < t->element_count; i++) {
+        if (pos >= (int)sizeof(buf) - 1) {
+            fprintf(stderr, "Error: tuple type name too long (exceeds %d bytes)\n", (int)sizeof(buf));
+            exit(1);
+        }
         pos += snprintf(buf + pos, sizeof(buf) - (size_t)pos, "_%s", ast_type_str(t->element_types[i]));
     }
     // Sanitize: replace non-alnum with _

--- a/compiler/src/main.c
+++ b/compiler/src/main.c
@@ -17,6 +17,7 @@
 #else
 #  include <unistd.h>
 #  include <limits.h>
+#  include <sys/wait.h>
 #endif
 
 #include "config.h"
@@ -205,7 +206,14 @@ int main(int argc, char **argv) {
     if (emit_c) {
         printf("%s", cbuf.data);
     } else {
-        const char *c_path = "_urus_tmp.c";
+        // Generate unique temp filename to prevent TOCTOU race conditions
+        char c_path_buf[256];
+#ifdef _WIN32
+        snprintf(c_path_buf, sizeof(c_path_buf), "_urus_tmp_%d.c", (int)GetCurrentProcessId());
+#else
+        snprintf(c_path_buf, sizeof(c_path_buf), "_urus_tmp_%d.c", (int)getpid());
+#endif
+        const char *c_path = c_path_buf;
 #ifdef _WIN32
         const char *default_out = run_after ? "_urus_run.exe" : "a.exe";
 #else
@@ -262,13 +270,21 @@ int main(int argc, char **argv) {
                                "-o", out_path,
                                c_path, "-lm", NULL);
 #else
-        // Runtime header is embedded in generated C, no -I needed
-        char cmd[8192];
-        snprintf(cmd, sizeof(cmd),
-                 "%s -std=c11 -O2 -o \"%s\" \"%s\" -lm",
-                 gcc_path, out_path, c_path);
-        printf("Compiling: %s\n", cmd);
-        int ret = system(cmd);
+        // Use fork/execvp to avoid shell injection via system()
+        printf("Compiling: %s -std=c11 -O2 -o %s %s -lm\n", gcc_path, out_path, c_path);
+        int ret;
+        pid_t pid = fork();
+        if (pid == 0) {
+            execlp(gcc_path, "gcc", "-std=c11", "-O2",
+                   "-o", out_path, c_path, "-lm", (char *)NULL);
+            _exit(127); // exec failed
+        } else if (pid < 0) {
+            ret = -1;
+        } else {
+            int status;
+            waitpid(pid, &status, 0);
+            ret = WIFEXITED(status) ? WEXITSTATUS(status) : 1;
+        }
 #endif
 
         remove(c_path);


### PR DESCRIPTION
## Summary

- **Integer overflow in `urus_str_replace`** — add overflow check before `count * diff` size calculation to prevent heap buffer overflow. Also replace `strcpy` with bounded `memcpy`. (Closes #120)
- **Predictable temp file TOCTOU** — use PID-based unique filenames (`_urus_tmp_<pid>.c`) instead of a fixed `_urus_tmp.c` to prevent race conditions on shared systems. (Closes #122)
- **Command injection via `system()`** — replace `system()` with `fork()`/`execlp()` on Unix to avoid shell metacharacter injection. Windows already uses `_spawnl()`. (Closes #123)
- **Tuple type name truncation** — detect when the generated tuple type name exceeds the 512-byte buffer and abort with an error instead of silently producing incorrect C code. (Closes #126)

## Test plan

- [x] All 32 run tests pass with `--emit-c`
- [x] All valid/invalid tests pass
- [x] Compiler builds clean on Windows (MSVC)