### PR TITLE
refractor: replace all `malloc` to `xmalloc` for safer memory management

### DIFF
--- a/compiler/include/common.h
+++ b/compiler/include/common.h
@@ -5,12 +5,14 @@
 #include <stdio.h>
 #include <limits.h>
 
+// --  Path Separator  --
 #ifdef _WIN32
     #define URUSC_PATHSEP '\\'
 #else
     #define URUSC_PATHSEP '/'
 #endif
 
+// --  Path Maximum  --
 #ifndef PATH_MAX
     #ifdef MAX_PATH
         #define PATH_MAX MAX_PATH
@@ -18,22 +20,5 @@
         #define PATH_MAX 4096 /* safe default value */
     #endif
 #endif
-
-static void *xmalloc(size_t size) {
-    void *ptr = malloc(size);
-    if (!ptr) {
-        fprintf(stderr, "Memory allocation failed; out of memory.\n");
-        abort();
-    }
-    return ptr;
-}
-
-#define xfree(ptr) __xfree((void **)&(ptr))
-static void __xfree(void **ptr) {
-    if (ptr != NULL && *ptr != NULL) {
-        free(*ptr);
-        *ptr = NULL;
-    }
-}
 
 #endif

--- a/compiler/include/util.h
+++ b/compiler/include/util.h
@@ -5,4 +5,11 @@
 
 char *read_file(const char *path, size_t *out_len);
 
+// --  Memory Management  --
+#define xfree(ptr) __xfree((void **)&(ptr))
+#define xrealloc(ptr, size) __xrealloc((void **)&(ptr), size)
+void *xmalloc(size_t size);
+void *__xrealloc(void **ptr, size_t size);
+void __xfree(void **ptr);
+
 #endif

--- a/compiler/src/Sema/scope.c
+++ b/compiler/src/Sema/scope.c
@@ -1,4 +1,5 @@
 #include "scope.h"
+#include "util.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -6,13 +7,13 @@ SemaScope *scope_new(SemaScope *parent) {
     SemaScope *s = calloc(1, sizeof(SemaScope));
     s->parent = parent;
     s->cap = 8;
-    s->syms = malloc(sizeof(SemaSymbol) * (size_t)s->cap);
+    s->syms = xmalloc(sizeof(SemaSymbol) * (size_t)s->cap);
     return s;
 }
 
 void scope_free(SemaScope *s) {
-    free(s->syms);
-    free(s);
+    xfree(s->syms);
+    xfree(s);
 }
 
 SemaSymbol *scope_lookup_local(SemaScope *s, const char *name) {
@@ -33,7 +34,7 @@ SemaSymbol *scope_lookup(SemaScope *s, const char *name) {
 SemaSymbol *scope_add(SemaScope *s, const char *name, Token tok) {
     if (s->count >= s->cap) {
         s->cap *= 2;
-        s->syms = realloc(s->syms, sizeof(SemaSymbol) * (size_t)s->cap);
+        s->syms = xrealloc(s->syms, sizeof(SemaSymbol) * (size_t)s->cap);
     }
     SemaSymbol *sym = &s->syms[s->count++];
     memset(sym, 0, sizeof(SemaSymbol));

--- a/compiler/src/Sema/sema.c
+++ b/compiler/src/Sema/sema.c
@@ -3,6 +3,7 @@
 #endif
 
 #include "sema.h"
+#include "util.h"
 #include "./scope.h"
 #include "error.h"
 #include <stdio.h>
@@ -236,11 +237,11 @@ static AstType *check_expr(SemaCtx *ctx, AstNode *node) {
                     node->as.call.callee->as.ident.name = strdup(fn_name_buf);
 
                     int new_count = node->as.call.arg_count + 1;
-                    AstNode **new_args = malloc(sizeof(AstNode *) * (size_t)new_count);
+                    AstNode **new_args = xmalloc(sizeof(AstNode *) * (size_t)new_count);
                     new_args[0] = obj;
                     for (int i = 0; i < node->as.call.arg_count; i++)
                         new_args[i + 1] = node->as.call.args[i];
-                    free(node->as.call.args);
+                    xfree(node->as.call.args);
                     node->as.call.args = new_args;
                     node->as.call.arg_count = new_count;
                     // Fall through to normal call checking below
@@ -314,7 +315,7 @@ static AstType *check_expr(SemaCtx *ctx, AstNode *node) {
 
 		// Inject default parameter types to args
 		if (node->as.call.arg_count < sym->param_count) {
-            AstNode **new_args = malloc(sizeof(AstNode *) * (size_t)sym->param_count);
+            AstNode **new_args = xmalloc(sizeof(AstNode *) * (size_t)sym->param_count);
 
             for (int i = 0; i < node->as.call.arg_count; i++) {
                 new_args[i] = node->as.call.args[i];
@@ -327,7 +328,7 @@ static AstType *check_expr(SemaCtx *ctx, AstNode *node) {
                 }
             }
 
-            free(node->as.call.args);
+            xfree(node->as.call.args);
             node->as.call.args = new_args;
             node->as.call.arg_count = sym->param_count;
 		}
@@ -534,7 +535,7 @@ static AstType *check_expr(SemaCtx *ctx, AstNode *node) {
 
     case NODE_TUPLE_LIT: {
         int count = node->as.tuple_lit.count;
-        AstType **elem_types = malloc(sizeof(AstType *) * (size_t)count);
+        AstType **elem_types = xmalloc(sizeof(AstType *) * (size_t)count);
         for (int i = 0; i < count; i++) {
             AstType *t = check_expr(ctx, node->as.tuple_lit.elements[i]);
             elem_types[i] = t ? ast_type_clone(t) : ast_type_simple(TYPE_VOID);
@@ -853,7 +854,7 @@ static void check_stmt(SemaCtx *ctx, AstNode *node) {
 
                 // Store binding types for codegen
                 if (arm->binding_count > 0) {
-                    arm->binding_types = malloc(sizeof(AstType *) * (size_t)arm->binding_count);
+                    arm->binding_types = xmalloc(sizeof(AstType *) * (size_t)arm->binding_count);
                     for (int b = 0; b < arm->binding_count && b < variant->field_count; b++) {
                         arm->binding_types[b] = ast_type_clone(variant->fields[b].type);
                     }

--- a/compiler/src/ast.c
+++ b/compiler/src/ast.c
@@ -3,6 +3,7 @@
 #endif
 
 #include "ast.h"
+#include "util.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -61,7 +62,7 @@ AstType *ast_type_tuple(AstType **elems, int count) {
 }
 
 char *ast_strdup(const char *s, size_t len) {
-    char *d = malloc(len + 1);
+    char *d = xmalloc(len + 1);
     memcpy(d, s, len);
     d[len] = '\0';
     return d;
@@ -79,7 +80,7 @@ AstType *ast_type_clone(AstType *t) {
         c->param_count = t->param_count;
         c->return_type = ast_type_clone(t->return_type);
         if (t->param_count > 0) {
-            c->param_types = malloc(sizeof(AstType *) * (size_t)t->param_count);
+            c->param_types = xmalloc(sizeof(AstType *) * (size_t)t->param_count);
             for (int i = 0; i < t->param_count; i++)
                 c->param_types[i] = ast_type_clone(t->param_types[i]);
         }
@@ -87,7 +88,7 @@ AstType *ast_type_clone(AstType *t) {
     if (t->kind == TYPE_TUPLE) {
         c->element_count = t->element_count;
         if (t->element_count > 0) {
-            c->element_types = malloc(sizeof(AstType *) * (size_t)t->element_count);
+            c->element_types = xmalloc(sizeof(AstType *) * (size_t)t->element_count);
             for (int i = 0; i < t->element_count; i++)
                 c->element_types[i] = ast_type_clone(t->element_types[i]);
         }
@@ -480,22 +481,22 @@ void ast_print(AstNode *node, int ind) {
 
 void ast_type_free(AstType *type) {
     if (!type) return;
-    free(type->name);
+    xfree(type->name);
     ast_type_free(type->element);
     ast_type_free(type->ok_type);
     ast_type_free(type->err_type);
     if (type->kind == TYPE_FN) {
         for (int i = 0; i < type->param_count; i++)
             ast_type_free(type->param_types[i]);
-        free(type->param_types);
+        xfree(type->param_types);
         ast_type_free(type->return_type);
     }
     if (type->kind == TYPE_TUPLE) {
         for (int i = 0; i < type->element_count; i++)
             ast_type_free(type->element_types[i]);
-        free(type->element_types);
+        xfree(type->element_types);
     }
-    free(type);
+    xfree(type);
 }
 
 void ast_free(AstNode *node) {
@@ -505,37 +506,37 @@ void ast_free(AstNode *node) {
     case NODE_PROGRAM:
         for (int i = 0; i < node->as.program.decl_count; i++)
             ast_free(node->as.program.decls[i]);
-        free(node->as.program.decls);
+        xfree(node->as.program.decls);
         break;
     case NODE_FN_DECL:
-        free(node->as.fn_decl.name);
+        xfree(node->as.fn_decl.name);
         for (int i = 0; i < node->as.fn_decl.param_count; i++) {
-            free(node->as.fn_decl.params[i].name);
+            xfree(node->as.fn_decl.params[i].name);
             ast_type_free(node->as.fn_decl.params[i].type);
         }
-        free(node->as.fn_decl.params);
+        xfree(node->as.fn_decl.params);
         ast_type_free(node->as.fn_decl.return_type);
         ast_free(node->as.fn_decl.body);
         break;
     case NODE_STRUCT_DECL:
-        free(node->as.struct_decl.name);
+        xfree(node->as.struct_decl.name);
         for (int i = 0; i < node->as.struct_decl.field_count; i++) {
-            free(node->as.struct_decl.fields[i].name);
+            xfree(node->as.struct_decl.fields[i].name);
             ast_type_free(node->as.struct_decl.fields[i].type);
         }
-        free(node->as.struct_decl.fields);
+        xfree(node->as.struct_decl.fields);
         break;
     case NODE_BLOCK:
         for (int i = 0; i < node->as.block.stmt_count; i++)
             ast_free(node->as.block.stmts[i]);
-        free(node->as.block.stmts);
+        xfree(node->as.block.stmts);
         break;
     case NODE_LET_STMT:
-        free(node->as.let_stmt.name);
+        xfree(node->as.let_stmt.name);
         if (node->as.let_stmt.is_destructure) {
             for (int i = 0; i < node->as.let_stmt.name_count; i++)
-                free(node->as.let_stmt.names[i]);
-            free(node->as.let_stmt.names);
+                xfree(node->as.let_stmt.names[i]);
+            xfree(node->as.let_stmt.names);
         }
         ast_type_free(node->as.let_stmt.type);
         ast_free(node->as.let_stmt.init);
@@ -558,11 +559,11 @@ void ast_free(AstNode *node) {
         ast_free(node->as.do_while_stmt.condition);
         break;
     case NODE_FOR_STMT:
-        free(node->as.for_stmt.var_name);
+        xfree(node->as.for_stmt.var_name);
         if (node->as.for_stmt.is_destructure) {
             for (int i = 0; i < node->as.for_stmt.var_count; i++)
-                free(node->as.for_stmt.var_names[i]);
-            free(node->as.for_stmt.var_names);
+                xfree(node->as.for_stmt.var_names[i]);
+            xfree(node->as.for_stmt.var_names);
         }
         ast_free(node->as.for_stmt.start);
         ast_free(node->as.for_stmt.end);
@@ -576,7 +577,7 @@ void ast_free(AstNode *node) {
         ast_free(node->as.expr_stmt.expr);
         break;
     case NODE_EMIT_STMT:
-        free(node->as.emit_stmt.content);
+        xfree(node->as.emit_stmt.content);
         break;
     case NODE_BINARY:
         ast_free(node->as.binary.left);
@@ -589,71 +590,71 @@ void ast_free(AstNode *node) {
         ast_free(node->as.call.callee);
         for (int i = 0; i < node->as.call.arg_count; i++)
             ast_free(node->as.call.args[i]);
-        free(node->as.call.args);
+        xfree(node->as.call.args);
         break;
     case NODE_FIELD_ACCESS:
         ast_free(node->as.field_access.object);
-        free(node->as.field_access.field);
+        xfree(node->as.field_access.field);
         break;
     case NODE_INDEX:
         ast_free(node->as.index_expr.object);
         ast_free(node->as.index_expr.index);
         break;
-    case NODE_STR_LIT: free(node->as.str_lit.value); break;
-    case NODE_IDENT: free(node->as.ident.name); break;
+    case NODE_STR_LIT: xfree(node->as.str_lit.value); break;
+    case NODE_IDENT: xfree(node->as.ident.name); break;
     case NODE_ARRAY_LIT:
         for (int i = 0; i < node->as.array_lit.count; i++)
             ast_free(node->as.array_lit.elements[i]);
-        free(node->as.array_lit.elements);
+        xfree(node->as.array_lit.elements);
         break;
     case NODE_STRUCT_LIT:
-        free(node->as.struct_lit.name);
+        xfree(node->as.struct_lit.name);
         for (int i = 0; i < node->as.struct_lit.field_count; i++) {
-            free(node->as.struct_lit.fields[i].name);
+            xfree(node->as.struct_lit.fields[i].name);
             ast_free(node->as.struct_lit.fields[i].value);
         }
-        free(node->as.struct_lit.fields);
+        xfree(node->as.struct_lit.fields);
         ast_free(node->as.struct_lit.spread);
         break;
     case NODE_ENUM_DECL:
-        free(node->as.enum_decl.name);
+        xfree(node->as.enum_decl.name);
         for (int i = 0; i < node->as.enum_decl.variant_count; i++) {
-            free(node->as.enum_decl.variants[i].name);
+            xfree(node->as.enum_decl.variants[i].name);
             for (int j = 0; j < node->as.enum_decl.variants[i].field_count; j++) {
-                free(node->as.enum_decl.variants[i].fields[j].name);
+                xfree(node->as.enum_decl.variants[i].fields[j].name);
                 ast_type_free(node->as.enum_decl.variants[i].fields[j].type);
             }
-            free(node->as.enum_decl.variants[i].fields);
+            xfree(node->as.enum_decl.variants[i].fields);
         }
-        free(node->as.enum_decl.variants);
+        xfree(node->as.enum_decl.variants);
         break;
     case NODE_MATCH:
         ast_free(node->as.match_stmt.target);
         for (int i = 0; i < node->as.match_stmt.arm_count; i++) {
-            free(node->as.match_stmt.arms[i].enum_name);
-            free(node->as.match_stmt.arms[i].variant_name);
+            xfree(node->as.match_stmt.arms[i].enum_name);
+            xfree(node->as.match_stmt.arms[i].variant_name);
             for (int j = 0; j < node->as.match_stmt.arms[i].binding_count; j++)
-                free(node->as.match_stmt.arms[i].bindings[j]);
-            free(node->as.match_stmt.arms[i].bindings);
+                xfree(node->as.match_stmt.arms[i].bindings[j]);
+            xfree(node->as.match_stmt.arms[i].bindings);
             if (node->as.match_stmt.arms[i].binding_types) {
                 for (int j = 0; j < node->as.match_stmt.arms[i].binding_count; j++)
                     ast_type_free(node->as.match_stmt.arms[i].binding_types[j]);
-                free(node->as.match_stmt.arms[i].binding_types);
+                xfree(node->as.match_stmt.arms[i].binding_types);
             }
             ast_free(node->as.match_stmt.arms[i].pattern_expr);
             ast_free(node->as.match_stmt.arms[i].body);
         }
-        free(node->as.match_stmt.arms);
+        xfree(node->as.match_stmt.arms);
         break;
     case NODE_ENUM_INIT:
-        free(node->as.enum_init.enum_name);
-        free(node->as.enum_init.variant_name);
+        xfree(node->as.enum_init.enum_name);
+        xfree(node->as.enum_init.variant_name);
         for (int i = 0; i < node->as.enum_init.arg_count; i++)
             ast_free(node->as.enum_init.args[i]);
-        free(node->as.enum_init.args);
+        xfree(node->as.enum_init.args);
         break;
     case NODE_IMPORT:
-        free(node->as.import_decl.path);
+        xfree(node->as.import_decl.path);
         break;
     case NODE_OK_EXPR:
     case NODE_ERR_EXPR:
@@ -661,23 +662,23 @@ void ast_free(AstNode *node) {
         break;
     case NODE_LAMBDA:
         for (int i = 0; i < node->as.lambda.param_count; i++) {
-            free(node->as.lambda.params[i].name);
+            xfree(node->as.lambda.params[i].name);
             ast_type_free(node->as.lambda.params[i].type);
         }
-        free(node->as.lambda.params);
+        xfree(node->as.lambda.params);
         ast_type_free(node->as.lambda.return_type);
         ast_free(node->as.lambda.body);
         for (int i = 0; i < node->as.lambda.capture_count; i++) {
-            free(node->as.lambda.captures[i]);
+            xfree(node->as.lambda.captures[i]);
             ast_type_free(node->as.lambda.capture_types[i]);
         }
-        free(node->as.lambda.captures);
-        free(node->as.lambda.capture_types);
+        xfree(node->as.lambda.captures);
+        xfree(node->as.lambda.capture_types);
         break;
     case NODE_TUPLE_LIT:
         for (int i = 0; i < node->as.tuple_lit.count; i++)
             ast_free(node->as.tuple_lit.elements[i]);
-        free(node->as.tuple_lit.elements);
+        xfree(node->as.tuple_lit.elements);
         break;
     case NODE_IF_EXPR:
         ast_free(node->as.if_expr.condition);
@@ -685,19 +686,19 @@ void ast_free(AstNode *node) {
         ast_free(node->as.if_expr.else_expr);
         break;
     case NODE_RUNE_DECL:
-        free(node->as.rune_decl.name);
+        xfree(node->as.rune_decl.name);
         for (int i = 0; i < node->as.rune_decl.param_count; i++)
-            free(node->as.rune_decl.param_names[i]);
-        free(node->as.rune_decl.param_names);
-        free(node->as.rune_decl.body_tokens);
+            xfree(node->as.rune_decl.param_names[i]);
+        xfree(node->as.rune_decl.param_names);
+        xfree(node->as.rune_decl.body_tokens);
         break;
     case NODE_CONST_DECL:
-        free(node->as.const_decl.name);
+        xfree(node->as.const_decl.name);
         ast_type_free(node->as.const_decl.type);
         ast_free(node->as.const_decl.value);
         break;
     case NODE_TYPE_ALIAS:
-        free(node->as.type_alias.name);
+        xfree(node->as.type_alias.name);
         ast_type_free(node->as.type_alias.type);
         break;
     case NODE_DEFER_STMT:
@@ -710,5 +711,5 @@ void ast_free(AstNode *node) {
     case NODE_CONTINUE_STMT:
         break;
     }
-    free(node);
+    xfree(node);
 }

--- a/compiler/src/codegen.c
+++ b/compiler/src/codegen.c
@@ -1,5 +1,6 @@
 #include "config.h"
 #include "codegen.h"
+#include "util.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -228,20 +229,20 @@ static void collect_and_emit_tuple_typedefs(CodeBuf *buf, AstNode *node) {
 void codegen_init(CodeBuf *buf) {
     buf->cap = 8192;
     buf->len = 0;
-    buf->data = malloc(buf->cap);
+    buf->data = xmalloc(buf->cap);
     buf->data[0] = '\0';
     buf->indent = 0;
     buf->tmp_counter = 0;
 }
 
 void codegen_free(CodeBuf *buf) {
-    free(buf->data);
+    xfree(buf->data);
 }
 
 static void buf_ensure(CodeBuf *buf, size_t extra) {
     while (buf->len + extra + 1 >= buf->cap) {
         buf->cap *= 2;
-        buf->data = realloc(buf->data, buf->cap);
+        buf->data = xrealloc(buf->data, buf->cap);
     }
 }
 

--- a/compiler/src/lexer.c
+++ b/compiler/src/lexer.c
@@ -1,4 +1,5 @@
 #include "lexer.h"
+#include "util.h"
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
@@ -334,19 +335,19 @@ Token lexer_next(Lexer *l) {
 Token *lexer_tokenize(Lexer *l, int *count) {
     int cap = 256;
     int n = 0;
-    Token *tokens = malloc(sizeof(Token) * (size_t)cap);
+    Token *tokens = xmalloc(sizeof(Token) * (size_t)cap);
 
     while (1) {
         if (n >= cap) {
             cap *= 2;
-            tokens = realloc(tokens, sizeof(Token) * (size_t)cap);
+            tokens = xrealloc(tokens, sizeof(Token) * (size_t)cap);
         }
         tokens[n] = lexer_next(l);
         if (tokens[n].type == TOK_EOF) { n++; break; }
         if (tokens[n].type == TOK_ERROR) {
             fprintf(stderr, "Lexer error at line %d: %.*s\n",
                     tokens[n].line, (int)tokens[n].length, tokens[n].start);
-            free(tokens);
+            xfree(tokens);
             *count = 0;
             return NULL;
         }

--- a/compiler/src/main.c
+++ b/compiler/src/main.c
@@ -20,6 +20,7 @@
 #endif
 
 #include "config.h"
+#include "common.h"
 #include "util.h"
 #include "lexer.h"
 #include "parser.h"
@@ -161,7 +162,7 @@ int main(int argc, char **argv) {
     int token_count;
     Token *tokens = lexer_tokenize(&lexer, &token_count);
     if (!tokens) {
-        free(source);
+        xfree(source);
         return 1;
     }
 
@@ -283,8 +284,8 @@ int main(int argc, char **argv) {
             // Execute the compiled binary
             codegen_free(&cbuf);
             ast_free(program);
-            free(tokens);
-            free(source);
+            xfree(tokens);
+            xfree(source);
 
 #ifdef _WIN32
             int run_ret = (int)_spawnl(_P_WAIT, out_path, out_path, NULL);
@@ -303,13 +304,13 @@ int main(int argc, char **argv) {
 
     codegen_free(&cbuf);
     ast_free(program);
-    free(tokens);
-    free(source);
+    xfree(tokens);
+    xfree(source);
     return 0;
 
 cleanup_err:
     ast_free(program);
-    free(tokens);
-    free(source);
+    xfree(tokens);
+    xfree(source);
     return 1;
 }

--- a/compiler/src/parser.c
+++ b/compiler/src/parser.c
@@ -3,6 +3,7 @@
 #endif
 
 #include "parser.h"
+#include "util.h"
 #include "error.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -79,7 +80,7 @@ static char *tok_str_value(Token t) {
 
 // Strip underscores from numeric literal for strtoll/strtod
 static char *tok_num_str(Token t) {
-    char *buf = malloc(t.length + 1);
+    char *buf = xmalloc(t.length + 1);
     size_t j = 0;
     for (size_t i = 0; i < t.length; i++) {
         if (t.start[i] != '_') buf[j++] = t.start[i];
@@ -130,12 +131,12 @@ static AstType *parse_type(Parser *p) {
     // Tuple type: (T1, T2, ...)
     if (match(p, TOK_LPAREN)) {
         int cap = 4, count = 0;
-        AstType **elems = malloc(sizeof(AstType *) * (size_t)cap);
+        AstType **elems = xmalloc(sizeof(AstType *) * (size_t)cap);
         if (!check(p, TOK_RPAREN)) {
             do {
                 if (count >= cap) {
                     cap *= 2;
-                    elems = realloc(elems, sizeof(AstType *) * (size_t)cap);
+                    elems = xrealloc(elems, sizeof(AstType *) * (size_t)cap);
                 }
                 elems[count++] = parse_type(p);
             } while (match(p, TOK_COMMA));
@@ -187,7 +188,7 @@ static AstNode *parse_fstring(Parser *p, Token t) {
             }
             // Build the literal with escaped braces resolved
             size_t seg_len = i - start;
-            char *buf = malloc(seg_len + 1);
+            char *buf = xmalloc(seg_len + 1);
             size_t j = 0;
             for (size_t k = start; k < i; k++) {
                 if (raw[k] == '{' && k + 1 < i && raw[k + 1] == '{') { buf[j++] = '{'; k++; }
@@ -237,7 +238,7 @@ static AstNode *parse_fstring(Parser *p, Token t) {
                 to_str_ident->as.ident.name = strdup("to_str");
                 AstNode *call = ast_new(NODE_CALL, t);
                 call->as.call.callee = to_str_ident;
-                call->as.call.args = malloc(sizeof(AstNode *));
+                call->as.call.args = xmalloc(sizeof(AstNode *));
                 call->as.call.args[0] = expr;
                 call->as.call.arg_count = 1;
 
@@ -250,7 +251,7 @@ static AstNode *parse_fstring(Parser *p, Token t) {
                     bin->as.binary.right = call;
                     result = bin;
                 }
-                free(sub_tokens);
+                xfree(sub_tokens);
             }
         } else {
             // Collect literal text until { or end
@@ -303,14 +304,14 @@ static AstNode *parse_primary(Parser *p) {
         if (errno == ERANGE) {
             warn_at(p, t, "integer literal out of range");
         }
-        free(s);
+        xfree(s);
         return n;
     }
     if (match(p, TOK_FLOAT_LIT)) {
         AstNode *n = ast_new(NODE_FLOAT_LIT, t);
         char *s = tok_num_str(t);
         n->as.float_lit.value = strtod(s, NULL);
-        free(s);
+        xfree(s);
         return n;
     }
     if (match(p, TOK_STR_LIT)) {
@@ -364,16 +365,16 @@ static AstNode *parse_primary(Parser *p) {
                     // Collect argument token spans
                     // Each argument is a span of tokens delimited by , or )
                     int arg_cap = 8;
-                    Token **arg_tokens = malloc(sizeof(Token *) * (size_t)arg_cap);
-                    int *arg_lens = malloc(sizeof(int) * (size_t)arg_cap);
+                    Token **arg_tokens = xmalloc(sizeof(Token *) * (size_t)arg_cap);
+                    int *arg_lens = xmalloc(sizeof(int) * (size_t)arg_cap);
                     int arg_count = 0;
 
                     if (!check(p, TOK_RPAREN)) {
                         while (1) {
                             if (arg_count >= arg_cap) {
                                 arg_cap *= 2;
-                                arg_tokens = realloc(arg_tokens, sizeof(Token *) * (size_t)arg_cap);
-                                arg_lens = realloc(arg_lens, sizeof(int) * (size_t)arg_cap);
+                                arg_tokens = xrealloc(arg_tokens, sizeof(Token *) * (size_t)arg_cap);
+                                arg_lens = xrealloc(arg_lens, sizeof(int) * (size_t)arg_cap);
                             }
                             int start = p->pos;
                             int depth2 = 0;
@@ -403,13 +404,13 @@ static AstNode *parse_primary(Parser *p) {
                         snprintf(msg, sizeof(msg), "rune '%s' expects %d arguments, got %d", rune->name, rune->param_count, arg_count);
                         error_at(p, t, msg);
                     }
-                        free(arg_tokens); free(arg_lens); free(name);
+                        xfree(arg_tokens); xfree(arg_lens); xfree(name);
                         return ast_new(NODE_INT_LIT, t);
                     }
 
                     // Build expanded token stream: substitute params with arg tokens
                     size_t exp_cap = (size_t)rune->body_token_count * 2 + 16;
-                    Token *expanded = malloc(sizeof(Token) * exp_cap);
+                    Token *expanded = xmalloc(sizeof(Token) * exp_cap);
                     int exp_count = 0;
 
                     for (int i = 0; i < rune->body_token_count; i++) {
@@ -423,7 +424,7 @@ static AstNode *parse_primary(Parser *p) {
                                     size_t needed = (size_t)exp_count + (size_t)arg_lens[j] + 1;
                                     if (needed >= exp_cap) {
                                         exp_cap = needed * 2;
-                                        expanded = realloc(expanded, sizeof(Token) * exp_cap);
+                                        expanded = xrealloc(expanded, sizeof(Token) * exp_cap);
                                     }
                                     for (int k = 0; k < arg_lens[j]; k++) {
                                         expanded[exp_count++] = arg_tokens[j][k];
@@ -436,7 +437,7 @@ static AstNode *parse_primary(Parser *p) {
                         if (!substituted) {
                             if ((size_t)exp_count >= exp_cap) {
                                 exp_cap *= 2;
-                                expanded = realloc(expanded, sizeof(Token) * exp_cap);
+                                expanded = xrealloc(expanded, sizeof(Token) * exp_cap);
                             }
                             expanded[exp_count++] = bt;
                         }
@@ -445,7 +446,7 @@ static AstNode *parse_primary(Parser *p) {
                     // Add EOF token
                     if ((size_t)exp_count >= exp_cap) {
                         exp_cap++;
-                        expanded = realloc(expanded, sizeof(Token) * exp_cap);
+                        expanded = xrealloc(expanded, sizeof(Token) * exp_cap);
                     }
                     Token eof_tok = {TOK_EOF, "", 0, t.line, t.col};
                     expanded[exp_count++] = eof_tok;
@@ -473,7 +474,7 @@ static AstNode *parse_primary(Parser *p) {
                             stmts[stmt_count++] = parse_statement(p);
                         }
                         result = ast_new(NODE_BLOCK, t);
-                        result->as.block.stmts = malloc(sizeof(AstNode *) * (size_t)stmt_count);
+                        result->as.block.stmts = xmalloc(sizeof(AstNode *) * (size_t)stmt_count);
                         memcpy(result->as.block.stmts, stmts, sizeof(AstNode *) * (size_t)stmt_count);
                         result->as.block.stmt_count = stmt_count;
                     } else {
@@ -485,10 +486,10 @@ static AstNode *parse_primary(Parser *p) {
                     p->count = saved_count;
                     p->pos = saved_pos;
 
-                    free(expanded);
-                    free(arg_tokens);
-                    free(arg_lens);
-                    free(name);
+                    xfree(expanded);
+                    xfree(arg_tokens);
+                    xfree(arg_lens);
+                    xfree(name);
                     return result;
                 }
                 // Not a rune — backtrack
@@ -510,12 +511,12 @@ static AstNode *parse_primary(Parser *p) {
                 int arg_cap = 4, arg_count = 0;
                 AstNode **args = NULL;
                 if (match(p, TOK_LPAREN)) {
-                    args = malloc(sizeof(AstNode *) * (size_t)arg_cap);
+                    args = xmalloc(sizeof(AstNode *) * (size_t)arg_cap);
                     if (!check(p, TOK_RPAREN)) {
                         do {
                             if (arg_count >= arg_cap) {
                                 arg_cap *= 2;
-                                args = realloc(args, sizeof(AstNode *) * (size_t)arg_cap);
+                                args = xrealloc(args, sizeof(AstNode *) * (size_t)arg_cap);
                             }
                             args[arg_count++] = parse_expr(p);
                         } while (match(p, TOK_COMMA));
@@ -565,7 +566,7 @@ static AstNode *parse_primary(Parser *p) {
                     AstNode *n = ast_new(NODE_STRUCT_LIT, t);
                     n->as.struct_lit.name = name;
                     int cap = 4, count = 0;
-                    FieldInit *fields = malloc(sizeof(FieldInit) * (size_t)cap);
+                    FieldInit *fields = xmalloc(sizeof(FieldInit) * (size_t)cap);
                     AstNode *spread = NULL;
                     do {
                         // Trailing comma: allow } after comma
@@ -578,7 +579,7 @@ static AstNode *parse_primary(Parser *p) {
                         }
                         if (count >= cap) {
                             cap *= 2;
-                            fields = realloc(fields, sizeof(FieldInit) * (size_t)cap);
+                            fields = xrealloc(fields, sizeof(FieldInit) * (size_t)cap);
                         }
                         Token fname = expect(p, TOK_IDENT, "expected field name");
                         expect(p, TOK_COLON, "expected ':' in struct literal");
@@ -604,12 +605,12 @@ static AstNode *parse_primary(Parser *p) {
     if (match(p, TOK_LBRACKET)) {
         AstNode *n = ast_new(NODE_ARRAY_LIT, t);
         int cap = 4, count = 0;
-        AstNode **elems = malloc(sizeof(AstNode *) * (size_t)cap);
+        AstNode **elems = xmalloc(sizeof(AstNode *) * (size_t)cap);
         if (!check(p, TOK_RBRACKET)) {
             do {
                 if (count >= cap) {
                     cap *= 2;
-                    elems = realloc(elems, sizeof(AstNode *) * (size_t)cap);
+                    elems = xrealloc(elems, sizeof(AstNode *) * (size_t)cap);
                 }
                 elems[count++] = parse_expr(p);
             } while (match(p, TOK_COMMA));
@@ -625,13 +626,13 @@ static AstNode *parse_primary(Parser *p) {
         if (match(p, TOK_COMMA)) {
             // Tuple literal: (e1, e2, ...)
             int cap = 4, count = 1;
-            AstNode **elems = malloc(sizeof(AstNode *) * (size_t)cap);
+            AstNode **elems = xmalloc(sizeof(AstNode *) * (size_t)cap);
             elems[0] = first;
             if (!check(p, TOK_RPAREN)) {
                 do {
                     if (count >= cap) {
                         cap *= 2;
-                        elems = realloc(elems, sizeof(AstNode *) * (size_t)cap);
+                        elems = xrealloc(elems, sizeof(AstNode *) * (size_t)cap);
                     }
                     elems[count++] = parse_expr(p);
                 } while (match(p, TOK_COMMA));
@@ -673,12 +674,12 @@ static AstNode *parse_call(Parser *p) {
     while (true) {
         if (match(p, TOK_LPAREN)) {
             int cap = 4, count = 0;
-            AstNode **args = malloc(sizeof(AstNode *) * (size_t)cap);
+            AstNode **args = xmalloc(sizeof(AstNode *) * (size_t)cap);
             if (!check(p, TOK_RPAREN)) {
                 do {
                     if (count >= cap) {
                         cap *= 2;
-                        args = realloc(args, sizeof(AstNode *) * (size_t)cap);
+                        args = xrealloc(args, sizeof(AstNode *) * (size_t)cap);
                     }
                     args[count++] = parse_expr(p);
                 } while (match(p, TOK_COMMA));
@@ -813,11 +814,11 @@ static AstNode *parse_block(Parser *p) {
     expect(p, TOK_LBRACE, "expected '{'");
     AstNode *block = ast_new(NODE_BLOCK, previous(p));
     int cap = 8, count = 0;
-    AstNode **stmts = malloc(sizeof(AstNode *) * (size_t)cap);
+    AstNode **stmts = xmalloc(sizeof(AstNode *) * (size_t)cap);
     while (!check(p, TOK_RBRACE) && !at_end(p)) {
         if (count >= cap) {
             cap *= 2;
-            stmts = realloc(stmts, sizeof(AstNode *) * (size_t)cap);
+            stmts = xrealloc(stmts, sizeof(AstNode *) * (size_t)cap);
         }
         stmts[count++] = parse_statement(p);
         if (p->had_error) break;
@@ -853,7 +854,7 @@ static AstNode *parse_let(Parser *p) {
         n->as.let_stmt.type = type;
         n->as.let_stmt.init = init;
         n->as.let_stmt.is_destructure = true;
-        n->as.let_stmt.names = malloc(sizeof(char *) * (size_t)name_count);
+        n->as.let_stmt.names = xmalloc(sizeof(char *) * (size_t)name_count);
         memcpy(n->as.let_stmt.names, names, sizeof(char *) * (size_t)name_count);
         n->as.let_stmt.name_count = name_count;
         return n;
@@ -942,7 +943,7 @@ static AstNode *parse_for(Parser *p) {
         n->as.for_stmt.iterable = iterable;
         n->as.for_stmt.body = body;
         n->as.for_stmt.is_destructure = true;
-        n->as.for_stmt.var_names = malloc(sizeof(char *) * (size_t)name_count);
+        n->as.for_stmt.var_names = xmalloc(sizeof(char *) * (size_t)name_count);
         memcpy(n->as.for_stmt.var_names, names, sizeof(char *) * (size_t)name_count);
         n->as.for_stmt.var_count = name_count;
         return n;
@@ -1013,12 +1014,12 @@ static AstNode *parse_match(Parser *p) {
     expect(p, TOK_LBRACE, "expected '{' after match target");
 
     int cap = 4, count = 0;
-    MatchArm *arms = malloc(sizeof(MatchArm) * (size_t)cap);
+    MatchArm *arms = xmalloc(sizeof(MatchArm) * (size_t)cap);
 
     while (!check(p, TOK_RBRACE) && !at_end(p)) {
         if (count >= cap) {
             cap *= 2;
-            arms = realloc(arms, sizeof(MatchArm) * (size_t)cap);
+            arms = xrealloc(arms, sizeof(MatchArm) * (size_t)cap);
         }
 
         // Initialize arm defaults
@@ -1053,12 +1054,12 @@ static AstNode *parse_match(Parser *p) {
 
             if (match(p, TOK_LPAREN)) {
                 int bcap = 4, bcount = 0;
-                char **bindings = malloc(sizeof(char *) * (size_t)bcap);
+                char **bindings = xmalloc(sizeof(char *) * (size_t)bcap);
                 if (!check(p, TOK_RPAREN)) {
                     do {
                         if (bcount >= bcap) {
                             bcap *= 2;
-                            bindings = realloc(bindings, sizeof(char *) * (size_t)bcap);
+                            bindings = xrealloc(bindings, sizeof(char *) * (size_t)bcap);
                         }
                         Token b = expect(p, TOK_IDENT, "expected binding name");
                         bindings[bcount++] = tok_str(b);
@@ -1181,12 +1182,12 @@ static AstNode *parse_fn_decl(Parser *p) {
     expect(p, TOK_LPAREN, "expected '('");
 
     int cap = 4, count = 0;
-    Param *params = malloc(sizeof(Param) * (size_t)cap);
+    Param *params = xmalloc(sizeof(Param) * (size_t)cap);
     if (!check(p, TOK_RPAREN)) {
         do {
             if (count >= cap) {
                 cap *= 2;
-                params = realloc(params, sizeof(Param) * (size_t)cap);
+                params = xrealloc(params, sizeof(Param) * (size_t)cap);
             }
             bool param_mut = match(p, TOK_MUT);
             Token pname = expect(p, TOK_IDENT, "expected parameter name");
@@ -1236,11 +1237,11 @@ static AstNode *parse_struct_decl(Parser *p) {
     expect(p, TOK_LBRACE, "expected '{'");
 
     int cap = 4, count = 0;
-    Param *fields = malloc(sizeof(Param) * (size_t)cap);
+    Param *fields = xmalloc(sizeof(Param) * (size_t)cap);
     while (!check(p, TOK_RBRACE) && !at_end(p)) {
         if (count >= cap) {
             cap *= 2;
-            fields = realloc(fields, sizeof(Param) * (size_t)cap);
+            fields = xrealloc(fields, sizeof(Param) * (size_t)cap);
         }
         Token fname = expect(p, TOK_IDENT, "expected field name");
         if (p->had_error) break;
@@ -1268,12 +1269,12 @@ static AstNode *parse_enum_decl(Parser *p) {
     expect(p, TOK_LBRACE, "expected '{'");
 
     int cap = 4, count = 0;
-    EnumVariant *variants = malloc(sizeof(EnumVariant) * (size_t)cap);
+    EnumVariant *variants = xmalloc(sizeof(EnumVariant) * (size_t)cap);
 
     while (!check(p, TOK_RBRACE) && !at_end(p)) {
         if (count >= cap) {
             cap *= 2;
-            variants = realloc(variants, sizeof(EnumVariant) * (size_t)cap);
+            variants = xrealloc(variants, sizeof(EnumVariant) * (size_t)cap);
         }
         Token vname = expect(p, TOK_IDENT, "expected variant name");
         if (p->had_error) break;
@@ -1283,12 +1284,12 @@ static AstNode *parse_enum_decl(Parser *p) {
 
         if (match(p, TOK_LPAREN)) {
             int fcap = 4, fcount = 0;
-            Param *fields = malloc(sizeof(Param) * (size_t)fcap);
+            Param *fields = xmalloc(sizeof(Param) * (size_t)fcap);
             if (!check(p, TOK_RPAREN)) {
                 do {
                     if (fcount >= fcap) {
                         fcap *= 2;
-                        fields = realloc(fields, sizeof(Param) * (size_t)fcap);
+                        fields = xrealloc(fields, sizeof(Param) * (size_t)fcap);
                     }
                     Token fname = expect(p, TOK_IDENT, "expected field name");
                     if (p->had_error) break;
@@ -1351,12 +1352,12 @@ static AstNode *parse_rune_decl(Parser *p) {
     // Parse parameters
     expect(p, TOK_LPAREN, "expected '(' after rune name");
     int pcap = 4, pcount = 0;
-    char **params = malloc(sizeof(char *) * (size_t)pcap);
+    char **params = xmalloc(sizeof(char *) * (size_t)pcap);
     if (!check(p, TOK_RPAREN)) {
         do {
             if (pcount >= pcap) {
                 pcap *= 2;
-                params = realloc(params, sizeof(char *) * (size_t)pcap);
+                params = xrealloc(params, sizeof(char *) * (size_t)pcap);
             }
             Token pt = expect(p, TOK_IDENT, "expected parameter name");
             params[pcount++] = tok_str(pt);
@@ -1367,7 +1368,7 @@ static AstNode *parse_rune_decl(Parser *p) {
     // Collect body tokens between { and } (track brace nesting)
     expect(p, TOK_LBRACE, "expected '{' for rune body");
     int bcap = 32, bcount = 0;
-    Token *body = malloc(sizeof(Token) * (size_t)bcap);
+    Token *body = xmalloc(sizeof(Token) * (size_t)bcap);
     int depth = 1;
     while (!at_end(p) && depth > 0) {
         Token tok = current(p);
@@ -1378,7 +1379,7 @@ static AstNode *parse_rune_decl(Parser *p) {
         }
         if (bcount >= bcap) {
             bcap *= 2;
-            body = realloc(body, sizeof(Token) * (size_t)bcap);
+            body = xrealloc(body, sizeof(Token) * (size_t)bcap);
         }
         body[bcount++] = tok;
         advance_tok(p);
@@ -1388,11 +1389,11 @@ static AstNode *parse_rune_decl(Parser *p) {
     // Register in rune table
     if (rune_count < MAX_RUNES) {
         rune_defs[rune_count].name = strdup(name);
-        rune_defs[rune_count].param_names = malloc(sizeof(char *) * (size_t)pcount);
+        rune_defs[rune_count].param_names = xmalloc(sizeof(char *) * (size_t)pcount);
         for (int i = 0; i < pcount; i++)
             rune_defs[rune_count].param_names[i] = strdup(params[i]);
         rune_defs[rune_count].param_count = pcount;
-        rune_defs[rune_count].body_tokens = malloc(sizeof(Token) * (size_t)bcount);
+        rune_defs[rune_count].body_tokens = xmalloc(sizeof(Token) * (size_t)bcount);
         memcpy(rune_defs[rune_count].body_tokens, body, sizeof(Token) * (size_t)bcount);
         rune_defs[rune_count].body_token_count = bcount;
         rune_count++;
@@ -1454,12 +1455,12 @@ AstNode *parser_parse(Parser *p) {
     rune_count = 0; // reset rune table
     AstNode *program = ast_new(NODE_PROGRAM, current(p));
     int cap = 16, count = 0;
-    AstNode **decls = malloc(sizeof(AstNode *) * (size_t)cap);
+    AstNode **decls = xmalloc(sizeof(AstNode *) * (size_t)cap);
 
     while (!at_end(p) && !p->had_error) {
         if (count >= cap) {
             cap *= 2;
-            decls = realloc(decls, sizeof(AstNode *) * (size_t)cap);
+            decls = xrealloc(decls, sizeof(AstNode *) * (size_t)cap);
         }
         decls[count++] = parse_declaration(p);
     }

--- a/compiler/src/util.c
+++ b/compiler/src/util.c
@@ -12,7 +12,7 @@ char *read_file(const char *path, size_t *out_len) {
     size_t len = (size_t)ftell(f);
     fseek(f, 0, SEEK_SET);
 
-    char *buf = malloc(len + 1);
+    char *buf = xmalloc(len + 1);
     if (!buf) {
         fclose(f);
         return NULL;
@@ -23,4 +23,30 @@ char *read_file(const char *path, size_t *out_len) {
 
     if (out_len) *out_len = len;
     return buf;
+}
+
+// --  Memory Management  --
+void *xmalloc(size_t size) {
+    void *ptr = malloc(size);
+    if (!ptr) {
+        fprintf(stderr, "Memory allocation failed; out of memory.\n");
+        abort();
+    }
+    return ptr;
+}
+
+void *__xrealloc(void **ptr, size_t size) {
+    void *new_ptr = realloc(*ptr, size);
+    if (!new_ptr) {
+        fprintf(stderr, "Memory re-allocation failed; out of memory.\n");
+        abort();
+    }
+    return new_ptr;
+}
+
+void __xfree(void **ptr) {
+    if (ptr != NULL && *ptr != NULL) {
+        free(*ptr);
+        *ptr = NULL;
+    }
 }


### PR DESCRIPTION
- replace all `realloc` with `xrealloc`
- replace all `free` with `xfree`