### PR TITLE
CI/CD: Integrate CI/CD workflows, ensuring stable code before push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Urus CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake build-essential gcc
+
+    - name: Configure CMake
+      run: cmake -S compiler -B compiler/build -DCMAKE_BUILD_TYPE=Release
+
+    - name: Build Urus Compiler
+      run: cmake --build compiler/build --parallel $(nproc)
+
+    - name: Run CTest
+      run: ctest --test-dir compiler/build --output-on-failure --parallel $(nproc)


### PR DESCRIPTION
This **CI/CD** integration workflow so usefull to ensure stable code before pushing into the main/master branch.
Without it, we must manually run unit tests on Pull request