### PR TITLE
fix: detect buffer truncation for long identifiers in codegen/sema

### DIFF
--- a/compiler/codegen.c
+++ b/compiler/codegen.c
@@ -1666,9 +1666,14 @@ void codegen_generate(CodeBuf *buf, AstNode *program)
             for (int j = 0; j < d->as.struct_decl.field_count; j++) {
                 AstType *ft = d->as.struct_decl.fields[j].type;
                 if (type_needs_drop(ft)) {
-                    char field_acc[256];
-                    snprintf(field_acc, sizeof(field_acc), "(*obj)->%s",
+                    char field_acc[512];
+                    int fa_len = snprintf(field_acc, sizeof(field_acc), "(*obj)->%s",
                              d->as.struct_decl.fields[j].name);
+                    if (fa_len >= (int)sizeof(field_acc)) {
+                        fprintf(stderr, "Error: field name too long: %s\n",
+                                d->as.struct_decl.fields[j].name);
+                        exit(1);
+                    }
                     emit(buf, "        ");
                     emit_type_drop_cname(buf, ft, field_acc);
                 }
@@ -1696,9 +1701,13 @@ void codegen_generate(CodeBuf *buf, AstNode *program)
                          d->as.enum_decl.name, v->name);
                     for (int k = 0; k < v->field_count; k++) {
                         if (type_needs_drop(v->fields[k].type)) {
-                            char field_acc[256];
-                            snprintf(field_acc, sizeof(field_acc),
+                            char field_acc[512];
+                            int fa_len = snprintf(field_acc, sizeof(field_acc),
                                      "(*obj)->data.%s.f%d", v->name, k);
+                            if (fa_len >= (int)sizeof(field_acc)) {
+                                fprintf(stderr, "Error: variant name too long: %s\n", v->name);
+                                exit(1);
+                            }
                             emit(buf, "                ");
                             emit_type_drop_cname(buf, v->fields[k].type,
                                                  field_acc);

--- a/compiler/sema.c
+++ b/compiler/sema.c
@@ -308,16 +308,21 @@ static AstType *check_expr(SemaCtx *ctx, AstNode *node)
                 (obj_type->kind == TYPE_NAMED || obj_type->kind == TYPE_STR ||
                  obj_type->kind == TYPE_ARRAY)) {
                 // Build the function name
-                char fn_name_buf[256];
+                char fn_name_buf[512];
+                int fn_len;
                 if (obj_type->kind == TYPE_STR) {
-                    snprintf(fn_name_buf, sizeof(fn_name_buf), "str_%s",
+                    fn_len = snprintf(fn_name_buf, sizeof(fn_name_buf), "str_%s",
                              method);
                 } else if (obj_type->kind == TYPE_ARRAY) {
                     // Array methods map directly: arr.len() -> len(arr)
-                    snprintf(fn_name_buf, sizeof(fn_name_buf), "%s", method);
+                    fn_len = snprintf(fn_name_buf, sizeof(fn_name_buf), "%s", method);
                 } else {
-                    snprintf(fn_name_buf, sizeof(fn_name_buf), "%s_%s",
+                    fn_len = snprintf(fn_name_buf, sizeof(fn_name_buf), "%s_%s",
                              obj_type->name, method);
+                }
+                if (fn_len >= (int)sizeof(fn_name_buf)) {
+                    sema_error(ctx, &node->tok, "method name too long");
+                    return NULL;
                 }
                 SemaSymbol *method_sym =
                     scope_lookup(ctx->current, fn_name_buf);


### PR DESCRIPTION
Closes #141