### PR TITLE
feat: add stdlib modules (math, string, fs, json, os)

### DIFF
--- a/compiler/preprocess.c
+++ b/compiler/preprocess.c
@@ -58,11 +58,15 @@ void get_local_libpath(char *out, size_t size)
 {
 
 #if defined(_WIN32)
-    // Windows, check registry or fallback to default
-    const char *drive = getenv("SystemDrive");
-    if (!drive)
-        drive = "C:";
-    snprintf(out, size, "%s\\Program Files\\Urusc\\Lib", drive);
+    const char *prefix = getenv("URUSCPATH");
+    if (prefix) {
+        snprintf(out, size, "%s", prefix);
+    } else {
+        const char *drive = getenv("SystemDrive");
+        if (!drive)
+            drive = "C:";
+        snprintf(out, size, "%s\\Program Files\\Urusc\\Lib", drive);
+    }
 
 #elif defined(__ANDROID__)
     // Android / Termux

--- a/compiler/stdlib/fs.urus
+++ b/compiler/stdlib/fs.urus
@@ -1,0 +1,180 @@
+__emit__("""
+    #include <sys/stat.h>
+
+    #ifdef _WIN32
+    #include <windows.h>
+    #include <direct.h>
+    #else
+    #include <dirent.h>
+    #include <unistd.h>
+    #endif
+
+    static bool urus_fs_file_exists(urus_str *path) {
+        #ifdef _WIN32
+        DWORD attr = GetFileAttributesA(path->data);
+        return attr != INVALID_FILE_ATTRIBUTES;
+        #else
+        struct stat st;
+        return stat(path->data, &st) == 0;
+        #endif
+    }
+
+    static bool urus_fs_is_file(urus_str *path) {
+        #ifdef _WIN32
+        DWORD attr = GetFileAttributesA(path->data);
+        return attr != INVALID_FILE_ATTRIBUTES && !(attr & FILE_ATTRIBUTE_DIRECTORY);
+        #else
+        struct stat st;
+        if (stat(path->data, &st) != 0) return false;
+        return S_ISREG(st.st_mode);
+        #endif
+    }
+
+    static bool urus_fs_is_dir(urus_str *path) {
+        #ifdef _WIN32
+        DWORD attr = GetFileAttributesA(path->data);
+        return attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY);
+        #else
+        struct stat st;
+        if (stat(path->data, &st) != 0) return false;
+        return S_ISDIR(st.st_mode);
+        #endif
+    }
+
+    static int64_t urus_fs_file_size(urus_str *path) {
+        FILE *f = fopen(path->data, "rb");
+        if (!f) return -1;
+        fseek(f, 0, SEEK_END);
+        long size = ftell(f);
+        fclose(f);
+        return (int64_t)size;
+    }
+
+    static bool urus_fs_delete_file(urus_str *path) {
+        return remove(path->data) == 0;
+    }
+
+    static bool urus_fs_rename_file(urus_str *old_path, urus_str *new_path) {
+        return rename(old_path->data, new_path->data) == 0;
+    }
+
+    static urus_array *urus_fs_list_dir(urus_str *path) {
+        urus_array *arr = urus_array_new(sizeof(urus_str *), 8, (urus_drop_fn)urus_str_drop);
+        #ifdef _WIN32
+        char search_path[MAX_PATH];
+        snprintf(search_path, MAX_PATH, "%s\\*", path->data);
+        WIN32_FIND_DATAA fd;
+        HANDLE h = FindFirstFileA(search_path, &fd);
+        if (h == INVALID_HANDLE_VALUE) return arr;
+        do {
+            if (strcmp(fd.cFileName, ".") == 0 || strcmp(fd.cFileName, "..") == 0) continue;
+            urus_str *name = urus_str_from(fd.cFileName);
+            urus_array_push(arr, &name);
+        } while (FindNextFileA(h, &fd));
+        FindClose(h);
+        #else
+        DIR *d = opendir(path->data);
+        if (!d) return arr;
+        struct dirent *ent;
+        while ((ent = readdir(d)) != NULL) {
+            if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0) continue;
+            urus_str *name = urus_str_from(ent->d_name);
+            urus_array_push(arr, &name);
+        }
+        closedir(d);
+        #endif
+        return arr;
+    }
+
+    static bool urus_fs_mkdir(urus_str *path) {
+        #ifdef _WIN32
+        return CreateDirectoryA(path->data, NULL) != 0;
+        #else
+        return mkdir(path->data, 0755) == 0;
+        #endif
+    }
+
+    static urus_str *urus_fs_cwd(void) {
+        char buf[4096];
+        #ifdef _WIN32
+        DWORD len = GetCurrentDirectoryA(sizeof(buf), buf);
+        if (len == 0) return urus_str_from("");
+        return urus_str_new(buf, (size_t)len);
+        #else
+        if (getcwd(buf, sizeof(buf)) == NULL) return urus_str_from("");
+        return urus_str_from(buf);
+        #endif
+    }
+""");
+
+fn fs_file_exists(path: str): bool {
+    let result: bool = false;
+    __emit__("""
+        result = urus_fs_file_exists(path);
+    """);
+    return result;
+}
+
+fn fs_is_file(path: str): bool {
+    let result: bool = false;
+    __emit__("""
+        result = urus_fs_is_file(path);
+    """);
+    return result;
+}
+
+fn fs_is_dir(path: str): bool {
+    let result: bool = false;
+    __emit__("""
+        result = urus_fs_is_dir(path);
+    """);
+    return result;
+}
+
+fn fs_file_size(path: str): int {
+    let result: int = 0;
+    __emit__("""
+        result = urus_fs_file_size(path);
+    """);
+    return result;
+}
+
+fn fs_delete_file(path: str): bool {
+    let result: bool = false;
+    __emit__("""
+        result = urus_fs_delete_file(path);
+    """);
+    return result;
+}
+
+fn fs_rename_file(old_path: str, new_path: str): bool {
+    let result: bool = false;
+    __emit__("""
+        result = urus_fs_rename_file(old_path, new_path);
+    """);
+    return result;
+}
+
+fn fs_list_dir(path: str): [str] {
+    let result: [str] = [""];
+    __emit__("""
+        result = urus_fs_list_dir(path);
+    """);
+    return result;
+}
+
+fn fs_mkdir(path: str): bool {
+    let result: bool = false;
+    __emit__("""
+        result = urus_fs_mkdir(path);
+    """);
+    return result;
+}
+
+fn fs_cwd(): str {
+    let result: str = "";
+    __emit__("""
+        result = urus_fs_cwd();
+    """);
+    return result;
+}

--- a/compiler/stdlib/json.urus
+++ b/compiler/stdlib/json.urus
@@ -1,0 +1,329 @@
+__emit__("""
+    /* Skip whitespace */
+    static const char *_json_skip_ws(const char *p) {
+        while (*p == ' ' || *p == '\\t' || *p == '\\n' || *p == '\\r') p++;
+        return p;
+    }
+
+    /* Skip a JSON value (string, number, bool, null, object, array).
+       Returns pointer past the value. */
+    static const char *_json_skip_value(const char *p) {
+        p = _json_skip_ws(p);
+        if (*p == '"') {
+            p++;
+            while (*p && *p != '"') {
+                if (*p == '\\\\') p++;
+                p++;
+            }
+            if (*p == '"') p++;
+            return p;
+        }
+        if (*p == '{' || *p == '[') {
+            char open = *p, close = (*p == '{') ? '}' : ']';
+            int depth = 1;
+            p++;
+            while (*p && depth > 0) {
+                if (*p == '"') {
+                    p++;
+                    while (*p && *p != '"') {
+                        if (*p == '\\\\') p++;
+                        p++;
+                    }
+                    if (*p == '"') p++;
+                    continue;
+                }
+                if (*p == open) depth++;
+                else if (*p == close) depth--;
+                p++;
+            }
+            return p;
+        }
+        /* number, bool, null */
+        while (*p && *p != ',' && *p != '}' && *p != ']' &&
+               *p != ' ' && *p != '\\t' && *p != '\\n' && *p != '\\r') {
+            p++;
+        }
+        return p;
+    }
+
+    /* Find a key in a JSON object string. Returns pointer to the value
+       (after the colon), or NULL if not found. */
+    static const char *_json_find_key(const char *json, const char *key) {
+        const char *p = _json_skip_ws(json);
+        if (*p != '{') return NULL;
+        p++;
+        size_t key_len = strlen(key);
+        while (*p) {
+            p = _json_skip_ws(p);
+            if (*p == '}') return NULL;
+            if (*p == ',') { p++; continue; }
+            /* expect a string key */
+            if (*p != '"') return NULL;
+            p++;
+            const char *ks = p;
+            while (*p && *p != '"') {
+                if (*p == '\\\\') p++;
+                p++;
+            }
+            size_t kl = (size_t)(p - ks);
+            if (*p == '"') p++;
+            p = _json_skip_ws(p);
+            if (*p == ':') p++;
+            p = _json_skip_ws(p);
+            if (kl == key_len && memcmp(ks, key, key_len) == 0) {
+                return p;
+            }
+            /* skip the value */
+            p = _json_skip_value(p);
+        }
+        return NULL;
+    }
+
+    /* Extract a JSON value as a string. For string values, strips quotes.
+       For others, returns raw text. */
+    static urus_str *_json_extract_str(const char *p) {
+        p = _json_skip_ws(p);
+        if (*p == '"') {
+            p++;
+            /* find unescaped closing quote */
+            const char *start = p;
+            size_t cap = 256;
+            size_t len = 0;
+            char *buf = (char *)urus_alloc(cap);
+            while (*p && *p != '"') {
+                char c;
+                if (*p == '\\\\' && *(p + 1)) {
+                    p++;
+                    switch (*p) {
+                        case '"': c = '"'; break;
+                        case '\\\\': c = '\\\\'; break;
+                        case '/': c = '/'; break;
+                        case 'b': c = '\\b'; break;
+                        case 'f': c = '\\f'; break;
+                        case 'n': c = '\\n'; break;
+                        case 'r': c = '\\r'; break;
+                        case 't': c = '\\t'; break;
+                        default: c = *p; break;
+                    }
+                } else {
+                    c = *p;
+                }
+                if (len + 1 >= cap) {
+                    cap *= 2;
+                    buf = (char *)urus_realloc(buf, cap);
+                }
+                buf[len++] = c;
+                p++;
+            }
+            buf[len] = '\\0';
+            urus_str *result = urus_str_new(buf, len);
+            free(buf);
+            return result;
+        }
+        /* non-string value: extract raw text */
+        const char *start = p;
+        const char *end = _json_skip_value(p);
+        return urus_str_new(start, (size_t)(end - start));
+    }
+
+    static urus_str *urus_json_get(urus_str *json_str, urus_str *key) {
+        const char *val = _json_find_key(json_str->data, key->data);
+        if (!val) return urus_str_from("");
+        return _json_extract_str(val);
+    }
+
+    static int64_t urus_json_get_int(urus_str *json_str, urus_str *key) {
+        const char *val = _json_find_key(json_str->data, key->data);
+        if (!val) return 0;
+        return strtoll(val, NULL, 10);
+    }
+
+    static double urus_json_get_float(urus_str *json_str, urus_str *key) {
+        const char *val = _json_find_key(json_str->data, key->data);
+        if (!val) return 0.0;
+        return strtod(val, NULL);
+    }
+
+    static bool urus_json_get_bool(urus_str *json_str, urus_str *key) {
+        const char *val = _json_find_key(json_str->data, key->data);
+        if (!val) return false;
+        val = _json_skip_ws(val);
+        return *val == 't';
+    }
+
+    static urus_array *urus_json_get_array(urus_str *json_str, urus_str *key) {
+        urus_array *arr = urus_array_new(sizeof(urus_str *), 4, (urus_drop_fn)urus_str_drop);
+        const char *val = _json_find_key(json_str->data, key->data);
+        if (!val) return arr;
+        val = _json_skip_ws(val);
+        if (*val != '[') return arr;
+        val++;
+        while (*val) {
+            val = _json_skip_ws(val);
+            if (*val == ']') break;
+            if (*val == ',') { val++; continue; }
+            urus_str *elem = _json_extract_str(val);
+            urus_array_push(arr, &elem);
+            val = _json_skip_value(val);
+        }
+        return arr;
+    }
+
+    static urus_str *urus_json_escape(urus_str *s) {
+        size_t cap = s->len * 2 + 1;
+        char *buf = (char *)urus_alloc(cap);
+        size_t len = 0;
+        for (size_t i = 0; i < s->len; i++) {
+            if (len + 6 >= cap) {
+                cap *= 2;
+                buf = (char *)urus_realloc(buf, cap);
+            }
+            char c = s->data[i];
+            switch (c) {
+                case '"':  buf[len++] = '\\\\'; buf[len++] = '"'; break;
+                case '\\\\': buf[len++] = '\\\\'; buf[len++] = '\\\\'; break;
+                case '\\n': buf[len++] = '\\\\'; buf[len++] = 'n'; break;
+                case '\\r': buf[len++] = '\\\\'; buf[len++] = 'r'; break;
+                case '\\t': buf[len++] = '\\\\'; buf[len++] = 't'; break;
+                case '\\b': buf[len++] = '\\\\'; buf[len++] = 'b'; break;
+                case '\\f': buf[len++] = '\\\\'; buf[len++] = 'f'; break;
+                default:
+                    if ((unsigned char)c < 0x20) {
+                        len += snprintf(buf + len, cap - len, "\\\\u%04x", (unsigned char)c);
+                    } else {
+                        buf[len++] = c;
+                    }
+                    break;
+            }
+        }
+        buf[len] = '\\0';
+        urus_str *result = urus_str_new(buf, len);
+        free(buf);
+        return result;
+    }
+
+    static urus_str *urus_json_object(urus_array *keys, urus_array *values) {
+        size_t cap = 256;
+        char *buf = (char *)urus_alloc(cap);
+        size_t len = 0;
+        buf[len++] = '{';
+        size_t count = keys->len < values->len ? keys->len : values->len;
+        for (size_t i = 0; i < count; i++) {
+            urus_str *k = *(urus_str **)((char *)keys->data + i * keys->elem_size);
+            urus_str *v = *(urus_str **)((char *)values->data + i * values->elem_size);
+            /* need: ,"key":"value" */
+            size_t need = (i > 0 ? 1 : 0) + 1 + k->len + 3 + v->len + 1 + 1;
+            while (len + need >= cap) {
+                cap *= 2;
+                buf = (char *)urus_realloc(buf, cap);
+            }
+            if (i > 0) buf[len++] = ',';
+            buf[len++] = '"';
+            memcpy(buf + len, k->data, k->len); len += k->len;
+            buf[len++] = '"'; buf[len++] = ':'; buf[len++] = '"';
+            memcpy(buf + len, v->data, v->len); len += v->len;
+            buf[len++] = '"';
+        }
+        if (len + 2 >= cap) {
+            cap *= 2;
+            buf = (char *)urus_realloc(buf, cap);
+        }
+        buf[len++] = '}';
+        buf[len] = '\\0';
+        urus_str *result = urus_str_new(buf, len);
+        free(buf);
+        return result;
+    }
+
+    static urus_str *urus_json_array(urus_array *values) {
+        size_t cap = 256;
+        char *buf = (char *)urus_alloc(cap);
+        size_t len = 0;
+        buf[len++] = '[';
+        for (size_t i = 0; i < values->len; i++) {
+            urus_str *v = *(urus_str **)((char *)values->data + i * values->elem_size);
+            size_t need = (i > 0 ? 1 : 0) + 1 + v->len + 1 + 1;
+            while (len + need >= cap) {
+                cap *= 2;
+                buf = (char *)urus_realloc(buf, cap);
+            }
+            if (i > 0) buf[len++] = ',';
+            buf[len++] = '"';
+            memcpy(buf + len, v->data, v->len); len += v->len;
+            buf[len++] = '"';
+        }
+        if (len + 2 >= cap) {
+            cap *= 2;
+            buf = (char *)urus_realloc(buf, cap);
+        }
+        buf[len++] = ']';
+        buf[len] = '\\0';
+        urus_str *result = urus_str_new(buf, len);
+        free(buf);
+        return result;
+    }
+""");
+
+fn json_get(json_str: str, key: str): str {
+    let result: str = "";
+    __emit__("""
+        result = urus_json_get(json_str, key);
+    """);
+    return result;
+}
+
+fn json_get_int(json_str: str, key: str): int {
+    let result: int = 0;
+    __emit__("""
+        result = urus_json_get_int(json_str, key);
+    """);
+    return result;
+}
+
+fn json_get_float(json_str: str, key: str): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_json_get_float(json_str, key);
+    """);
+    return result;
+}
+
+fn json_get_bool(json_str: str, key: str): bool {
+    let result: bool = false;
+    __emit__("""
+        result = urus_json_get_bool(json_str, key);
+    """);
+    return result;
+}
+
+fn json_get_array(json_str: str, key: str): [str] {
+    let result: [str] = [""];
+    __emit__("""
+        result = urus_json_get_array(json_str, key);
+    """);
+    return result;
+}
+
+fn json_object(keys: [str], values: [str]): str {
+    let result: str = "";
+    __emit__("""
+        result = urus_json_object(keys, values);
+    """);
+    return result;
+}
+
+fn json_array(values: [str]): str {
+    let result: str = "";
+    __emit__("""
+        result = urus_json_array(values);
+    """);
+    return result;
+}
+
+fn json_escape(s: str): str {
+    let result: str = "";
+    __emit__("""
+        result = urus_json_escape(s);
+    """);
+    return result;
+}

--- a/compiler/stdlib/math.urus
+++ b/compiler/stdlib/math.urus
@@ -1,0 +1,201 @@
+__emit__("""
+    #include <time.h>
+
+    static bool _urus_math_seeded = false;
+
+    static void _urus_math_ensure_seed(void) {
+        if (!_urus_math_seeded) {
+            srand((unsigned int)time(NULL));
+            _urus_math_seeded = true;
+        }
+    }
+
+    static double urus_math_sin(double x) { return sin(x); }
+    static double urus_math_cos(double x) { return cos(x); }
+    static double urus_math_tan(double x) { return tan(x); }
+    static double urus_math_asin(double x) { return asin(x); }
+    static double urus_math_acos(double x) { return acos(x); }
+    static double urus_math_atan(double x) { return atan(x); }
+    static double urus_math_atan2(double y, double x) { return atan2(y, x); }
+
+    static double urus_math_log_val(double x) { return log(x); }
+    static double urus_math_log2_val(double x) { return log2(x); }
+    static double urus_math_log10_val(double x) { return log10(x); }
+
+    static double urus_math_ceil(double x) { return ceil(x); }
+    static double urus_math_floor(double x) { return floor(x); }
+    static double urus_math_round(double x) { return round(x); }
+
+    static double urus_math_clamp(double val, double lo, double hi) {
+        return val < lo ? lo : val > hi ? hi : val;
+    }
+
+    static double urus_math_sign(double x) {
+        if (x > 0.0) return 1.0;
+        if (x < 0.0) return -1.0;
+        return 0.0;
+    }
+
+    static double urus_math_lerp(double a, double b, double t) {
+        return a + t * (b - a);
+    }
+
+    static int64_t urus_math_random_int(int64_t min_val, int64_t max_val) {
+        _urus_math_ensure_seed();
+        if (min_val >= max_val) return min_val;
+        return min_val + (int64_t)(rand() % (int)(max_val - min_val + 1));
+    }
+
+    static double urus_math_random_float(void) {
+        _urus_math_ensure_seed();
+        return (double)rand() / (double)RAND_MAX;
+    }
+""");
+
+const MATH_PI: float = 3.14159265358979323846;
+const MATH_E: float = 2.71828182845904523536;
+const MATH_TAU: float = 6.28318530717958647692;
+
+fn math_sin(x: float): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_math_sin(x);
+    """);
+    return result;
+}
+
+fn math_cos(x: float): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_math_cos(x);
+    """);
+    return result;
+}
+
+fn math_tan(x: float): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_math_tan(x);
+    """);
+    return result;
+}
+
+fn math_asin(x: float): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_math_asin(x);
+    """);
+    return result;
+}
+
+fn math_acos(x: float): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_math_acos(x);
+    """);
+    return result;
+}
+
+fn math_atan(x: float): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_math_atan(x);
+    """);
+    return result;
+}
+
+fn math_atan2(y: float, x: float): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_math_atan2(y, x);
+    """);
+    return result;
+}
+
+fn math_log(x: float): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_math_log_val(x);
+    """);
+    return result;
+}
+
+fn math_log2(x: float): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_math_log2_val(x);
+    """);
+    return result;
+}
+
+fn math_log10(x: float): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_math_log10_val(x);
+    """);
+    return result;
+}
+
+fn math_ceil(x: float): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_math_ceil(x);
+    """);
+    return result;
+}
+
+fn math_floor(x: float): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_math_floor(x);
+    """);
+    return result;
+}
+
+fn math_round(x: float): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_math_round(x);
+    """);
+    return result;
+}
+
+fn math_clamp(val: float, lo: float, hi: float): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_math_clamp(val, lo, hi);
+    """);
+    return result;
+}
+
+fn math_sign(x: float): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_math_sign(x);
+    """);
+    return result;
+}
+
+fn math_lerp(a: float, b: float, t: float): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_math_lerp(a, b, t);
+    """);
+    return result;
+}
+
+fn math_random_int(min_val: int, max_val: int): int {
+    let result: int = 0;
+    __emit__("""
+        result = urus_math_random_int(min_val, max_val);
+    """);
+    return result;
+}
+
+fn math_random_float(): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_math_random_float();
+    """);
+    return result;
+}

--- a/compiler/stdlib/os.urus
+++ b/compiler/stdlib/os.urus
@@ -1,0 +1,200 @@
+__emit__("""
+    #include <time.h>
+
+    #ifdef _WIN32
+    #include <windows.h>
+    #else
+    #include <unistd.h>
+    #endif
+
+    static urus_str *urus_os_env_get(urus_str *name) {
+        const char *val = getenv(name->data);
+        if (val == NULL) return urus_str_from("");
+        return urus_str_from(val);
+    }
+
+    static void urus_os_env_set(urus_str *name, urus_str *value) {
+        #ifdef _WIN32
+        _putenv_s(name->data, value->data);
+        #else
+        setenv(name->data, value->data, 1);
+        #endif
+    }
+
+    static urus_str *urus_os_name(void) {
+        #ifdef _WIN32
+        return urus_str_from("windows");
+        #elif defined(__APPLE__)
+        return urus_str_from("macos");
+        #elif defined(__linux__)
+        return urus_str_from("linux");
+        #elif defined(__ANDROID__)
+        return urus_str_from("android");
+        #else
+        return urus_str_from("unknown");
+        #endif
+    }
+
+    static urus_str *urus_os_arch(void) {
+        #if defined(__x86_64__) || defined(_M_X64)
+        return urus_str_from("x86_64");
+        #elif defined(__aarch64__) || defined(_M_ARM64)
+        return urus_str_from("arm64");
+        #elif defined(__i386__) || defined(_M_IX86)
+        return urus_str_from("x86");
+        #elif defined(__arm__) || defined(_M_ARM)
+        return urus_str_from("arm");
+        #else
+        return urus_str_from("unknown");
+        #endif
+    }
+
+    static urus_str *urus_os_exec(urus_str *cmd) {
+        #ifdef _WIN32
+        FILE *fp = _popen(cmd->data, "r");
+        #else
+        FILE *fp = popen(cmd->data, "r");
+        #endif
+        if (!fp) {
+            fprintf(stderr, "Error: failed to execute command\\n");
+            return urus_str_from("");
+        }
+        size_t cap = 4096;
+        size_t len = 0;
+        char *buf = (char *)urus_alloc(cap);
+        size_t n;
+        while ((n = fread(buf + len, 1, cap - len - 1, fp)) > 0) {
+            len += n;
+            if (len + 1 >= cap) {
+                cap *= 2;
+                buf = (char *)urus_realloc(buf, cap);
+            }
+        }
+        #ifdef _WIN32
+        _pclose(fp);
+        #else
+        pclose(fp);
+        #endif
+        buf[len] = '\0';
+        urus_str *result = urus_str_new(buf, len);
+        free(buf);
+        return result;
+    }
+
+    static void urus_os_exit(int64_t code) {
+        exit((int)code);
+    }
+
+    static urus_array *urus_os_args(void) {
+        urus_array *arr = urus_array_new(sizeof(urus_str *), 4, (urus_drop_fn)urus_str_drop);
+        #ifdef _WIN32
+        extern int __argc;
+        extern char **__argv;
+        for (int i = 0; i < __argc; i++) {
+            urus_str *s = urus_str_from(__argv[i]);
+            urus_array_push(arr, &s);
+        }
+        #elif defined(__linux__)
+        FILE *f = fopen("/proc/self/cmdline", "rb");
+        if (f) {
+            char buf[4096];
+            size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+            fclose(f);
+            buf[n] = '\0';
+            size_t i = 0;
+            while (i < n) {
+                urus_str *s = urus_str_from(buf + i);
+                urus_array_push(arr, &s);
+                i += strlen(buf + i) + 1;
+            }
+        }
+        #elif defined(__APPLE__)
+        #include <crt_externs.h>
+        int argc = *_NSGetArgc();
+        char **argv = *_NSGetArgv();
+        for (int i = 0; i < argc; i++) {
+            urus_str *s = urus_str_from(argv[i]);
+            urus_array_push(arr, &s);
+        }
+        #endif
+        return arr;
+    }
+
+    static double urus_os_clock(void) {
+        return (double)clock() / (double)CLOCKS_PER_SEC;
+    }
+
+    static void urus_os_sleep_ms(int64_t ms) {
+        #ifdef _WIN32
+        Sleep((DWORD)ms);
+        #else
+        usleep((useconds_t)(ms * 1000));
+        #endif
+    }
+""");
+
+fn os_env_get(name: str): str {
+    let result: str = "";
+    __emit__("""
+        result = urus_os_env_get(name);
+    """);
+    return result;
+}
+
+fn os_env_set(name: str, value: str): void {
+    __emit__("""
+        urus_os_env_set(name, value);
+    """);
+}
+
+fn os_name(): str {
+    let result: str = "";
+    __emit__("""
+        result = urus_os_name();
+    """);
+    return result;
+}
+
+fn os_arch(): str {
+    let result: str = "";
+    __emit__("""
+        result = urus_os_arch();
+    """);
+    return result;
+}
+
+fn os_exec(cmd: str): str {
+    let result: str = "";
+    __emit__("""
+        result = urus_os_exec(cmd);
+    """);
+    return result;
+}
+
+fn os_exit(code: int): void {
+    __emit__("""
+        urus_os_exit(code);
+    """);
+}
+
+fn os_args(): [str] {
+    let result: [str] = [""];
+    __emit__("""
+        result = urus_os_args();
+    """);
+    return result;
+}
+
+fn os_clock(): float {
+    let result: float = 0.0;
+    __emit__("""
+        result = urus_os_clock();
+    """);
+    return result;
+}
+
+fn os_sleep_ms(ms: int): void {
+    __emit__("""
+        urus_os_sleep_ms(ms);
+    """);
+}

--- a/compiler/stdlib/string.urus
+++ b/compiler/stdlib/string.urus
@@ -1,0 +1,203 @@
+__emit__("""
+    static urus_str *urus_str_repeat(urus_str *s, int64_t n) {
+        if (n <= 0 || s->len == 0) return urus_str_from("");
+        size_t total = s->len * (size_t)n;
+        char *buf = (char *)urus_alloc(total + 1);
+        for (int64_t i = 0; i < n; i++) {
+            memcpy(buf + i * s->len, s->data, s->len);
+        }
+        buf[total] = '\0';
+        urus_str *result = urus_str_new(buf, total);
+        free(buf);
+        return result;
+    }
+
+    static urus_str *urus_str_pad_left(urus_str *s, int64_t width, urus_str *pad_char) {
+        if ((int64_t)s->len >= width) return urus_str_new(s->data, s->len);
+        size_t pad_len = (size_t)(width - (int64_t)s->len);
+        char *buf = (char *)urus_alloc((size_t)width + 1);
+        char pc = (pad_char->len > 0) ? pad_char->data[0] : ' ';
+        memset(buf, pc, pad_len);
+        memcpy(buf + pad_len, s->data, s->len);
+        buf[width] = '\0';
+        urus_str *result = urus_str_new(buf, (size_t)width);
+        free(buf);
+        return result;
+    }
+
+    static urus_str *urus_str_pad_right(urus_str *s, int64_t width, urus_str *pad_char) {
+        if ((int64_t)s->len >= width) return urus_str_new(s->data, s->len);
+        size_t pad_len = (size_t)(width - (int64_t)s->len);
+        char *buf = (char *)urus_alloc((size_t)width + 1);
+        memcpy(buf, s->data, s->len);
+        char pc = (pad_char->len > 0) ? pad_char->data[0] : ' ';
+        memset(buf + s->len, pc, pad_len);
+        buf[width] = '\0';
+        urus_str *result = urus_str_new(buf, (size_t)width);
+        free(buf);
+        return result;
+    }
+
+    static urus_str *urus_str_reverse_str(urus_str *s) {
+        char *buf = (char *)urus_alloc(s->len + 1);
+        for (size_t i = 0; i < s->len; i++) {
+            buf[i] = s->data[s->len - 1 - i];
+        }
+        buf[s->len] = '\0';
+        urus_str *result = urus_str_new(buf, s->len);
+        free(buf);
+        return result;
+    }
+
+    static int64_t urus_str_count(urus_str *s, urus_str *substr) {
+        if (substr->len == 0 || s->len == 0) return 0;
+        int64_t count = 0;
+        const char *p = s->data;
+        while ((p = strstr(p, substr->data)) != NULL) {
+            count++;
+            p += substr->len;
+        }
+        return count;
+    }
+
+    static urus_str *urus_str_join(urus_array *arr, urus_str *sep) {
+        if (arr->len == 0) return urus_str_from("");
+        size_t total = 0;
+        for (size_t i = 0; i < arr->len; i++) {
+            urus_str *elem = *(urus_str **)((char *)arr->data + i * arr->elem_size);
+            total += elem->len;
+            if (i > 0) total += sep->len;
+        }
+        char *buf = (char *)urus_alloc(total + 1);
+        size_t pos = 0;
+        for (size_t i = 0; i < arr->len; i++) {
+            if (i > 0 && sep->len > 0) {
+                memcpy(buf + pos, sep->data, sep->len);
+                pos += sep->len;
+            }
+            urus_str *elem = *(urus_str **)((char *)arr->data + i * arr->elem_size);
+            memcpy(buf + pos, elem->data, elem->len);
+            pos += elem->len;
+        }
+        buf[total] = '\0';
+        urus_str *result = urus_str_new(buf, total);
+        free(buf);
+        return result;
+    }
+
+    static urus_array *urus_str_chars(urus_str *s) {
+        urus_array *arr = urus_array_new(sizeof(urus_str *), s->len > 0 ? s->len : 1, (urus_drop_fn)urus_str_drop);
+        for (size_t i = 0; i < s->len; i++) {
+            urus_str *c = urus_str_new(s->data + i, 1);
+            urus_array_push(arr, &c);
+        }
+        return arr;
+    }
+
+    static bool urus_str_is_empty(urus_str *s) {
+        return s->len == 0;
+    }
+
+    static bool urus_str_is_numeric(urus_str *s) {
+        if (s->len == 0) return false;
+        size_t start = 0;
+        bool has_dot = false;
+        if (s->data[0] == '-' && s->len > 1) start = 1;
+        for (size_t i = start; i < s->len; i++) {
+            if (s->data[i] == '.' && !has_dot) {
+                has_dot = true;
+                continue;
+            }
+            if (!isdigit((unsigned char)s->data[i])) return false;
+        }
+        return true;
+    }
+
+    static bool urus_str_is_alpha(urus_str *s) {
+        if (s->len == 0) return false;
+        for (size_t i = 0; i < s->len; i++) {
+            if (!isalpha((unsigned char)s->data[i])) return false;
+        }
+        return true;
+    }
+""");
+
+fn str_repeat(s: str, n: int): str {
+    let result: str = "";
+    __emit__("""
+        result = urus_str_repeat(s, n);
+    """);
+    return result;
+}
+
+fn str_pad_left(s: str, width: int, pad_char: str): str {
+    let result: str = "";
+    __emit__("""
+        result = urus_str_pad_left(s, width, pad_char);
+    """);
+    return result;
+}
+
+fn str_pad_right(s: str, width: int, pad_char: str): str {
+    let result: str = "";
+    __emit__("""
+        result = urus_str_pad_right(s, width, pad_char);
+    """);
+    return result;
+}
+
+fn str_reverse(s: str): str {
+    let result: str = "";
+    __emit__("""
+        result = urus_str_reverse_str(s);
+    """);
+    return result;
+}
+
+fn str_count(s: str, substr: str): int {
+    let result: int = 0;
+    __emit__("""
+        result = urus_str_count(s, substr);
+    """);
+    return result;
+}
+
+fn str_join(arr: [str], sep: str): str {
+    let result: str = "";
+    __emit__("""
+        result = urus_str_join(arr, sep);
+    """);
+    return result;
+}
+
+fn str_chars(s: str): [str] {
+    let result: [str] = [""];
+    __emit__("""
+        result = urus_str_chars(s);
+    """);
+    return result;
+}
+
+fn str_is_empty(s: str): bool {
+    let result: bool = false;
+    __emit__("""
+        result = urus_str_is_empty(s);
+    """);
+    return result;
+}
+
+fn str_is_numeric(s: str): bool {
+    let result: bool = false;
+    __emit__("""
+        result = urus_str_is_numeric(s);
+    """);
+    return result;
+}
+
+fn str_is_alpha(s: str): bool {
+    let result: bool = false;
+    __emit__("""
+        result = urus_str_is_alpha(s);
+    """);
+    return result;
+}

--- a/tests/run/stdlib_fs.urus
+++ b/tests/run/stdlib_fs.urus
@@ -1,0 +1,7 @@
+import fs;
+
+println(fs_cwd());
+println(fs_file_exists("tests/run/stdlib_fs.urus"));
+println(fs_is_file("tests/run/stdlib_fs.urus"));
+println(fs_is_dir("tests"));
+println(fs_file_size("tests/run/stdlib_fs.urus"));

--- a/tests/run/stdlib_json.urus
+++ b/tests/run/stdlib_json.urus
@@ -1,0 +1,19 @@
+import json;
+
+let data: str = "{\"name\":\"Urus\",\"version\":3,\"active\":true,\"tags\":[\"lang\",\"compiler\"]}";
+println(json_get(data, "name"));
+println(json_get_int(data, "version"));
+println(json_get_bool(data, "active"));
+
+let tags: [str] = json_get_array(data, "tags");
+println(tags[0]);
+println(tags[1]);
+
+let keys: [str] = ["lang", "year"];
+let vals: [str] = ["urus", "2026"];
+println(json_object(keys, vals));
+
+let items: [str] = ["one", "two", "three"];
+println(json_array(items));
+
+println(json_escape("hello \"world\"\nnewline"));

--- a/tests/run/stdlib_math.urus
+++ b/tests/run/stdlib_math.urus
@@ -1,0 +1,11 @@
+import math;
+
+println(math_sin(0.0));
+println(math_cos(0.0));
+println(math_floor(3.7));
+println(math_ceil(3.2));
+println(math_round(3.5));
+println(math_clamp(10.0, 0.0, 5.0));
+println(math_sign(-42.0));
+println(math_lerp(0.0, 10.0, 0.5));
+println(MATH_PI);

--- a/tests/run/stdlib_os.urus
+++ b/tests/run/stdlib_os.urus
@@ -1,0 +1,6 @@
+import os;
+
+println(os_name());
+println(os_arch());
+let t: float = os_clock();
+println(t >= 0.0);

--- a/tests/run/stdlib_string.urus
+++ b/tests/run/stdlib_string.urus
@@ -1,0 +1,12 @@
+import string;
+
+println(str_repeat("ab", 3));
+println(str_pad_left("hi", 6, "0"));
+println(str_pad_right("hi", 6, "."));
+println(str_reverse("hello"));
+println(str_count("banana", "an"));
+let parts: [str] = ["a", "b", "c"];
+println(str_join(parts, "-"));
+println(str_is_empty(""));
+println(str_is_numeric("123.45"));
+println(str_is_alpha("hello"));


### PR DESCRIPTION
## Summary
- Add 5 new stdlib modules to complement the existing `http` module:
  - **math** (18 functions + 3 constants): trig, log, rounding, random, PI/E/TAU
  - **string** (10 functions): repeat, pad, reverse, count, join, chars, validators
  - **fs** (9 functions): file_exists, is_file, is_dir, file_size, list_dir, mkdir, cwd
  - **json** (8 functions): parse/extract values, build objects/arrays, escape
  - **os** (9 functions): env vars, platform detection, exec, args, clock, sleep
- Add `URUSCPATH` env var support on Windows for stdlib path resolution
- All modules are cross-platform (Windows + POSIX)
- Test files included for each module

## Test plan
- [x] All 5 modules produce valid C output via `--emit-c`
- [x] Compiler builds without warnings